### PR TITLE
Propagate client info and handle empty IN clauses

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -38,6 +38,7 @@ pub struct ChainBuilder {
 impl ChainBuilder {
     /// Create a new ChainBuilder with the specified client
     pub fn new(client: Client) -> ChainBuilder {
+        let query = QueryBuilder::new(client.clone());
         ChainBuilder {
             client,
             table: None,
@@ -45,7 +46,7 @@ impl ChainBuilder {
             select: Vec::new(),
             as_name: None,
             db: None,
-            query: QueryBuilder::default(),
+            query,
             method: Method::Select,
             insert_update: Value::Null,
             sql_str: String::new(),

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -3,11 +3,11 @@
 pub mod common;
 pub mod join;
 
-use crate::types::{Common, Statement};
+use crate::types::{Client, Common, Statement};
 use serde_json::Value;
 
 /// Main query builder for constructing WHERE clauses and other query parts
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct QueryBuilder {
     /// WHERE clause statements
     pub(crate) statement: Vec<Statement>,
@@ -17,6 +17,27 @@ pub struct QueryBuilder {
     pub(crate) join: Vec<join::JoinBuilder>,
     /// Common clauses (WITH, UNION, LIMIT, etc.)
     pub(crate) query_common: Vec<Common>,
+    /// Database client type used for nested builders
+    pub(crate) client: Client,
+}
+
+impl QueryBuilder {
+    /// Create a new QueryBuilder for the specified client
+    pub fn new(client: Client) -> Self {
+        Self {
+            statement: Vec::new(),
+            raw: Vec::new(),
+            join: Vec::new(),
+            query_common: Vec::new(),
+            client,
+        }
+    }
+}
+
+impl Default for QueryBuilder {
+    fn default() -> Self {
+        Self::new(Client::Mysql)
+    }
 }
 
 /// SQL comparison operators


### PR DESCRIPTION
## Summary
- track client in `QueryBuilder` and use it when spawning nested builders
- include bind parameters for EXISTS/NOT EXISTS subqueries and build them with the correct client
- optimize placeholder generation and treat empty IN/HAVING lists as `1=0`/`1=1`
- add tests for empty IN clauses and EXISTS binds

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689948fc28b88324afa7c922109133e7