### PR TITLE
🛡️ Escape SQL identifiers and harden against DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+#### 🛡️ Identifier escaping (SQL injection hardening)
+- **Automatic identifier escaping** for the structured API. Table, column, and
+  alias names are now dialect-escaped — backticks for MySQL, double quotes for
+  SQLite/PostgreSQL — with embedded quote characters doubled. Qualified names
+  (`db.table.col`) are escaped segment-by-segment and `*` segments are preserved.
+  This neutralizes SQL injection through attacker-controlled identifiers (e.g. a
+  dynamic `ORDER BY` column from a request).
+  - Applied to: `WHERE` columns, `SELECT` columns, `[db.]table` references and
+    aliases, `INSERT`/`UPDATE` column keys, `GROUP BY` / `ORDER BY` columns,
+    `JOIN` tables/aliases/`ON` columns, CTE aliases, `where_column`,
+    `where_ilike`, `where_json_contains`, `join_using`, and the
+    `select_count/sum/avg/max/min/alias` helpers.
+  - **Not** escaped (expression/raw escape hatches, emitted verbatim — never pass
+    untrusted input): all `*_raw` methods, `table_raw`, `add_raw`, `raw_join`,
+    `on_raw`, and the `having*` helpers (which accept aggregate expressions like
+    `COUNT(*)`).
+
+#### 🧯 Denial-of-service hardening
+- `insert_many` no longer panics (index-out-of-bounds) on an empty row set.
+- `insert`, `insert_many`, and `update` no longer panic on a missing column
+  value; they bind `NULL` defensively instead. Debug `println!` calls on these
+  paths were removed.
+
+### ⚠️ Breaking change
+- Generated SQL now quotes identifiers. Pass **bare** names to the structured API
+  (`"name"`, not `` "`name`" ``); pre-quoting would be double-escaped. If you
+  relied on exact unquoted SQL output, update your expectations (or use the
+  `*_raw` methods for verbatim fragments). See the README "Security" section.
+
 ## [1.0.0] - 2025-08-10
 
 ### 🎉 Major Release - Complete Rewrite and Enhancement

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,8 @@ required-features = ["mysql"]
 name = "sqlite_test"
 path = "tests/sqlite_test.rs"
 required-features = ["sqlite"]
+
+[[test]]
+name = "security_test"
+path = "tests/security_test.rs"
+required-features = ["mysql", "sqlite"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A flexible and easy-to-use query builder for MySQL and SQLite in Rust. This libr
 - **Advanced JOINs**: FULL OUTER JOIN, CROSS JOIN, JOIN USING
 - **Raw SQL**: Fallback to raw SQL when needed
 - **Multiple Operations**: SELECT, INSERT, UPDATE, DELETE
+- **Injection-safe identifiers**: Table/column/alias names are dialect-escaped automatically (see [Security](#security))
 - **sqlx Integration**: Direct integration with sqlx for async database operations
 - **Modern Architecture**: Clean, modular codebase with better maintainability
 
@@ -503,6 +504,36 @@ The library is organized into several modules:
 - **`src/sqlite/`** - SQLite-specific compilation
 - **`src/sqlx_mysql.rs`** - MySQL sqlx integration (conditional compilation)
 - **`src/sqlx_sqlite.rs`** - SQLite sqlx integration (conditional compilation)
+- **`src/dialect.rs`** - Dialect-aware identifier escaping
+
+## Security
+
+Chain Builder is designed to be safe against SQL injection on **two** axes:
+
+- **Values** are always sent as bound parameters (`?`), never inlined into SQL.
+- **Identifiers** (table, column, and alias names) passed to the structured API
+  are automatically escaped for the active dialect — backticks for MySQL,
+  double quotes for SQLite/PostgreSQL — with any embedded quote character doubled.
+  Qualified names like `users.id` are escaped segment-by-segment
+  (`` `users`.`id` ``) and a `*` segment is preserved (`` `users`.* ``).
+
+This means you can safely pass an untrusted column name (e.g. a dynamic
+`ORDER BY` coming from a request) without it being able to break out of the
+identifier context:
+
+```rust
+// "name`; DROP TABLE users; --" becomes a single quoted identifier:
+//   ... ORDER BY `name``; DROP TABLE users; --` ASC
+qb.order_by(user_supplied_column, "ASC");
+```
+
+> **Pass bare identifiers.** Do **not** pre-quote names yourself (e.g. `` "`name`" ``);
+> the builder quotes them for you, and a pre-quoted name would be double-escaped.
+
+The `*_raw` methods (`select_raw`, `where_raw`, `group_by_raw`, `order_by_raw`,
+`having_raw`, `add_raw`, `table_raw`, `raw_join`, `on_raw`) and the `having*`
+helpers are **expression** escape hatches and are emitted verbatim — never pass
+untrusted input through them.
 
 ## Feature Flags
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -114,46 +114,48 @@ impl ChainBuilder {
     /// Add COUNT aggregate function
     pub fn select_count(&mut self, column: &str) -> &mut ChainBuilder {
         self.method = Method::Select;
-        self.select
-            .push(Select::Raw(format!("COUNT({})", column), None));
+        let column = crate::dialect::escape_identifier(column, &self.client);
+        self.select.push(Select::Raw(format!("COUNT({})", column), None));
         self
     }
 
     /// Add SUM aggregate function
     pub fn select_sum(&mut self, column: &str) -> &mut ChainBuilder {
         self.method = Method::Select;
-        self.select
-            .push(Select::Raw(format!("SUM({})", column), None));
+        let column = crate::dialect::escape_identifier(column, &self.client);
+        self.select.push(Select::Raw(format!("SUM({})", column), None));
         self
     }
 
     /// Add AVG aggregate function
     pub fn select_avg(&mut self, column: &str) -> &mut ChainBuilder {
         self.method = Method::Select;
-        self.select
-            .push(Select::Raw(format!("AVG({})", column), None));
+        let column = crate::dialect::escape_identifier(column, &self.client);
+        self.select.push(Select::Raw(format!("AVG({})", column), None));
         self
     }
 
     /// Add MAX aggregate function
     pub fn select_max(&mut self, column: &str) -> &mut ChainBuilder {
         self.method = Method::Select;
-        self.select
-            .push(Select::Raw(format!("MAX({})", column), None));
+        let column = crate::dialect::escape_identifier(column, &self.client);
+        self.select.push(Select::Raw(format!("MAX({})", column), None));
         self
     }
 
     /// Add MIN aggregate function
     pub fn select_min(&mut self, column: &str) -> &mut ChainBuilder {
         self.method = Method::Select;
-        self.select
-            .push(Select::Raw(format!("MIN({})", column), None));
+        let column = crate::dialect::escape_identifier(column, &self.client);
+        self.select.push(Select::Raw(format!("MIN({})", column), None));
         self
     }
 
     /// Add SELECT with alias
     pub fn select_alias(&mut self, column: &str, alias: &str) -> &mut ChainBuilder {
         self.method = Method::Select;
+        let column = crate::dialect::escape_identifier(column, &self.client);
+        let alias = crate::dialect::escape_identifier(alias, &self.client);
         self.select
             .push(Select::Raw(format!("{} AS {}", column, alias), None));
         self

--- a/src/common/join_compiler.rs
+++ b/src/common/join_compiler.rs
@@ -1,9 +1,10 @@
-use crate::{builder::ChainBuilder, query::join::JoinStatement};
+use crate::{builder::ChainBuilder, dialect::escape_identifier, query::join::JoinStatement};
 use serde_json::Value;
 
 pub fn join_compiler(chain_builder: &ChainBuilder, prefix: bool) -> (String, Vec<Value>) {
     let mut to_sql_str = String::new();
     let mut to_binds: Vec<serde_json::Value> = vec![];
+    let client = &chain_builder.query.client;
     for (i, join) in chain_builder.query.join.iter().enumerate() {
         if i > 0 {
             to_sql_str.push(' ');
@@ -17,12 +18,21 @@ pub fn join_compiler(chain_builder: &ChainBuilder, prefix: bool) -> (String, Vec
 
         if prefix {
             let table = if let Some(db) = &chain_builder.db {
-                format!("{}.{}", db, join.table)
+                format!(
+                    "{}.{}",
+                    escape_identifier(db, client),
+                    escape_identifier(&join.table, client)
+                )
             } else {
-                join.table.clone()
+                escape_identifier(&join.table, client)
             };
             if let Some(as_name) = &join.as_name {
-                to_sql_str.push_str(&format!("{} {} as {} ON ", join.join_type, table, as_name));
+                to_sql_str.push_str(&format!(
+                    "{} {} as {} ON ",
+                    join.join_type,
+                    table,
+                    escape_identifier(as_name, client)
+                ));
             } else {
                 to_sql_str.push_str(&format!("{} {} ON ", join.join_type, table));
             }
@@ -34,7 +44,15 @@ pub fn join_compiler(chain_builder: &ChainBuilder, prefix: bool) -> (String, Vec
                     if j > 0 {
                         to_sql_str.push_str(" AND ");
                     }
-                    to_sql_str.push_str(format!("{} {} {}", column, operator, column2).as_str());
+                    to_sql_str.push_str(
+                        format!(
+                            "{} {} {}",
+                            escape_identifier(column, client),
+                            operator,
+                            escape_identifier(column2, client)
+                        )
+                        .as_str(),
+                    );
                 }
                 JoinStatement::OrChain(qb) => {
                     if j > 0 {
@@ -50,7 +68,9 @@ pub fn join_compiler(chain_builder: &ChainBuilder, prefix: bool) -> (String, Vec
                     if j > 0 {
                         to_sql_str.push_str(" AND ");
                     }
-                    to_sql_str.push_str(format!("{} {} ?", column, operator).as_str());
+                    to_sql_str.push_str(
+                        format!("{} {} ?", escape_identifier(column, client), operator).as_str(),
+                    );
                     to_binds.push(value.clone());
                 }
                 JoinStatement::OnRaw(raw, binds) => {

--- a/src/common/method_compiler.rs
+++ b/src/common/method_compiler.rs
@@ -1,11 +1,34 @@
 use crate::{
     builder::ChainBuilder,
+    dialect::escape_identifier,
     types::{Method, Select},
 };
 use serde_json::Value;
 
 pub trait ToSqlProvider {
     fn to_sql(&self, chain_builder: &ChainBuilder) -> (String, Vec<Value>);
+}
+
+/// Compile the target table reference (`[db.]table` or a raw expression),
+/// escaping the `db`/`table` identifiers and collecting any raw binds.
+fn compile_table(chain_builder: &ChainBuilder, binds: &mut Vec<Value>) -> String {
+    let client = &chain_builder.query.client;
+    if let Some((table, val)) = &chain_builder.table_raw {
+        if let Some(val) = val {
+            binds.extend(val.clone());
+        }
+        table.clone()
+    } else if let Some(table) = &chain_builder.table {
+        let mut sql = String::new();
+        if let Some(db) = &chain_builder.db {
+            sql.push_str(&escape_identifier(db, client));
+            sql.push('.');
+        }
+        sql.push_str(&escape_identifier(table, client));
+        sql
+    } else {
+        String::new()
+    }
 }
 
 pub fn method_compiler_with_provider<T: ToSqlProvider>(
@@ -26,18 +49,10 @@ fn insert_into_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
     let mut insert_sql = String::new();
     let mut insert_binds: Vec<serde_json::Value> = vec![];
     insert_sql.push_str("INSERT INTO ");
+    let client = &chain_builder.query.client;
 
-    if let Some((table, val)) = &chain_builder.table_raw {
-        insert_sql.push_str(table);
-        if let Some(val) = val {
-            insert_binds.extend(val.clone());
-        }
-    } else if let Some(table) = &chain_builder.table {
-        if let Some(db) = &chain_builder.db {
-            insert_sql.push_str(format!("{}.", db).as_str());
-        }
-        insert_sql.push_str(table.as_str());
-    }
+    let table_sql = compile_table(chain_builder, &mut insert_binds);
+    insert_sql.push_str(&table_sql);
 
     insert_sql.push_str(" (");
     let mut is_first = true;
@@ -55,7 +70,7 @@ fn insert_into_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
         } else {
             insert_sql.push_str(", ");
         }
-        insert_sql.push_str(key.as_str());
+        insert_sql.push_str(&escape_identifier(key, client));
     }
     insert_sql.push_str(") VALUES (");
     is_first = true;
@@ -66,16 +81,10 @@ fn insert_into_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
             insert_sql.push_str(", ");
         }
         insert_sql.push('?');
-        match data.get(key.as_str()) {
-            Some(value) => {
-                insert_binds.push(value.clone());
-            }
-            None => {
-                println!("[Err] key: {:?}", key);
-                println!("[Err] data: {:?}", data);
-                panic!("[Err] insert_into_compiler: data.get(key.as_str()) is None");
-            }
-        }
+        // Keys come from `data`, so this lookup always succeeds; bind NULL as a
+        // defensive fallback instead of panicking on untrusted input.
+        let value = data.get(key.as_str()).cloned().unwrap_or(Value::Null);
+        insert_binds.push(value);
     }
 
     insert_sql.push(')');
@@ -89,17 +98,10 @@ fn insert_many_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
     let mut insert_binds: Vec<serde_json::Value> = vec![];
 
     insert_sql.push_str("INSERT INTO ");
-    if let Some((table, val)) = &chain_builder.table_raw {
-        insert_sql.push_str(table);
-        if let Some(val) = val {
-            insert_binds.extend(val.clone());
-        }
-    } else if let Some(table) = &chain_builder.table {
-        if let Some(db) = &chain_builder.db {
-            insert_sql.push_str(format!("{}.", db).as_str());
-        }
-        insert_sql.push_str(table.as_str());
-    }
+    let client = &chain_builder.query.client;
+
+    let table_sql = compile_table(chain_builder, &mut insert_binds);
+    insert_sql.push_str(&table_sql);
 
     insert_sql.push_str(" (");
     let mut is_first = true;
@@ -109,8 +111,11 @@ fn insert_many_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
         .insert_update
         .as_array()
         .unwrap_or(&vec_default);
-    let mut keys = data[0]
-        .as_object()
+    // Derive the column set from the first row; bail out gracefully on empty input
+    // instead of indexing `data[0]` (which would panic).
+    let mut keys = data
+        .first()
+        .and_then(|row| row.as_object())
         .unwrap_or(&map_default)
         .keys()
         .collect::<Vec<&String>>();
@@ -122,7 +127,7 @@ fn insert_many_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
         } else {
             insert_sql.push_str(", ");
         }
-        insert_sql.push_str(key.as_str());
+        insert_sql.push_str(&escape_identifier(key, client));
     }
     insert_sql.push_str(") VALUES ");
     is_first = true;
@@ -142,16 +147,10 @@ fn insert_many_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
                 insert_sql.push_str(", ");
             }
             insert_sql.push('?');
-            match row.get(key.as_str()) {
-                Some(value) => {
-                    insert_binds.push(value.clone());
-                }
-                None => {
-                    println!("[Err] key: {:?}", key);
-                    println!("[Err] row: {:?}", row);
-                    panic!("[Err] insert_many_compiler: row.get(key.as_str()) is None");
-                }
-            }
+            // Rows may be heterogeneous; bind NULL for a missing column instead
+            // of panicking so untrusted data can't crash the process.
+            let value = row.get(key.as_str()).cloned().unwrap_or(Value::Null);
+            insert_binds.push(value);
         }
         insert_sql.push(')');
     }
@@ -172,6 +171,7 @@ fn select_compiler<T: ToSqlProvider>(
         select_sql.push_str("SELECT ");
     }
 
+    let client = &chain_builder.query.client;
     if chain_builder.select.is_empty() {
         select_sql.push('*');
     } else {
@@ -184,7 +184,7 @@ fn select_compiler<T: ToSqlProvider>(
             }
             match select {
                 Select::Columns(columns) => {
-                    select_sql.push_str(&columns.join(", "));
+                    select_sql.push_str(&crate::dialect::escape_identifier_list(columns, client));
                 }
                 Select::Raw(sql, binds) => {
                     select_sql.push_str(sql.as_str());
@@ -197,7 +197,7 @@ fn select_compiler<T: ToSqlProvider>(
                     select_sql.push_str("(");
                     select_sql.push_str(&sub_sql);
                     select_sql.push_str(") AS ");
-                    select_sql.push_str(as_name.as_str());
+                    select_sql.push_str(&escape_identifier(as_name, client));
                     select_binds.extend(sub_binds);
                 }
             }
@@ -205,20 +205,11 @@ fn select_compiler<T: ToSqlProvider>(
     }
 
     select_sql.push_str(" FROM ");
-    if let Some((table, val)) = &chain_builder.table_raw {
-        select_sql.push_str(table);
-        if let Some(val) = val {
-            select_binds.extend(val.clone());
-        }
-    } else if let Some(table) = &chain_builder.table {
-        if let Some(db) = &chain_builder.db {
-            select_sql.push_str(format!("{}.", db).as_str());
-        }
-        select_sql.push_str(table.as_str());
-    }
+    let table_sql = compile_table(chain_builder, &mut select_binds);
+    select_sql.push_str(&table_sql);
     if let Some(as_name) = &chain_builder.as_name {
         select_sql.push_str(" AS ");
-        select_sql.push_str(as_name);
+        select_sql.push_str(&escape_identifier(as_name, client));
     }
     (select_sql, select_binds)
 }
@@ -229,17 +220,9 @@ fn update_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
     let mut update_binds: Vec<serde_json::Value> = vec![];
 
     update_sql.push_str("UPDATE ");
-    if let Some((table, val)) = &chain_builder.table_raw {
-        update_sql.push_str(table);
-        if let Some(val) = val {
-            update_binds.extend(val.clone());
-        }
-    } else if let Some(table) = &chain_builder.table {
-        if let Some(db) = &chain_builder.db {
-            update_sql.push_str(format!("{}.", db).as_str());
-        }
-        update_sql.push_str(table.as_str());
-    }
+    let client = &chain_builder.query.client;
+    let table_sql = compile_table(chain_builder, &mut update_binds);
+    update_sql.push_str(&table_sql);
     update_sql.push_str(" SET ");
     let map_default = serde_json::Map::new();
     let data = chain_builder
@@ -256,18 +239,11 @@ fn update_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
         } else {
             update_sql.push_str(", ");
         }
-        update_sql.push_str(key.as_str());
+        update_sql.push_str(&escape_identifier(key, client));
         update_sql.push_str(" = ?");
-        match data.get(key.as_str()) {
-            Some(value) => {
-                update_binds.push(value.clone());
-            }
-            None => {
-                println!("[Err] key: {:?}", key);
-                println!("[Err] data: {:?}", data);
-                panic!("[Err] update_compiler: data.get(key.as_str()) is None");
-            }
-        }
+        // Keys come from `data`; bind NULL defensively rather than panicking.
+        let value = data.get(key.as_str()).cloned().unwrap_or(Value::Null);
+        update_binds.push(value);
     }
 
     (update_sql, update_binds)
@@ -278,17 +254,8 @@ fn delete_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) {
     let mut delete_sql = String::new();
     let mut delete_binds: Vec<serde_json::Value> = vec![];
     delete_sql.push_str("DELETE FROM ");
-    if let Some((table, val)) = &chain_builder.table_raw {
-        delete_sql.push_str(table);
-        if let Some(val) = val {
-            delete_binds.extend(val.clone());
-        }
-    } else if let Some(table) = &chain_builder.table {
-        if let Some(db) = &chain_builder.db {
-            delete_sql.push_str(format!("{}.", db).as_str());
-        }
-        delete_sql.push_str(table.as_str());
-    }
+    let table_sql = compile_table(chain_builder, &mut delete_binds);
+    delete_sql.push_str(&table_sql);
 
     (delete_sql, delete_binds)
 }

--- a/src/common/statement_compiler.rs
+++ b/src/common/statement_compiler.rs
@@ -5,6 +5,7 @@ pub fn statement_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) 
     let mut statement_sql = String::new();
     let mut statement_binds: Vec<serde_json::Value> = vec![];
     let mut is_first = true;
+    let client = chain_builder.query.client.clone();
     let mut build_statement = |statement: &Statement| match statement {
         Statement::Value(field, operator, value) => {
             if (*operator == Operator::In || *operator == Operator::NotIn)
@@ -29,7 +30,7 @@ pub fn statement_compiler(chain_builder: &ChainBuilder) -> (String, Vec<Value>) 
             } else {
                 statement_sql.push_str(" AND ");
             }
-            statement_sql.push_str(field);
+            statement_sql.push_str(&crate::dialect::escape_identifier(field, &client));
             statement_sql.push(' ');
             if *operator == Operator::Between || *operator == Operator::NotBetween {
                 statement_sql.push_str(&format!("{} ? AND ?", operator_str));

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -1,0 +1,126 @@
+//! Dialect-aware SQL identifier escaping.
+//!
+//! Values are always sent to the database as bound parameters (`?`), but SQL
+//! *identifiers* (table names, column names, aliases) are interpolated directly
+//! into the generated SQL. If any of those identifiers can be influenced by
+//! untrusted input (e.g. a dynamic `ORDER BY` column coming from a request),
+//! interpolating them verbatim is a SQL-injection vector.
+//!
+//! [`escape_identifier`] quotes identifiers using the dialect's quote character
+//! and doubles any embedded quote character, which is the standard, injection-safe
+//! way to emit an identifier.
+
+use crate::types::Client;
+
+impl Client {
+    /// The identifier quote character for this dialect.
+    ///
+    /// MySQL uses backticks; SQLite and PostgreSQL use ANSI double quotes.
+    pub(crate) fn quote_char(&self) -> char {
+        match self {
+            Client::Mysql => '`',
+            Client::Sqlite | Client::Postgres => '"',
+        }
+    }
+}
+
+/// Escape a SQL identifier so that attacker-controlled table/column/alias names
+/// cannot break out of the identifier context.
+///
+/// Behaviour:
+/// - The identifier is split on `.` so qualified names like `db.table.col` are
+///   quoted segment-by-segment (`` `db`.`table`.`col` ``).
+/// - A bare `*` segment (wildcard) is passed through unquoted, so `t.*` becomes
+///   `` `t`.* `` and `*` stays `*`.
+/// - Any occurrence of the quote character inside a segment is doubled, which
+///   neutralizes attempts to terminate the quoted identifier early.
+/// - Surrounding whitespace is trimmed; empty input yields an empty string.
+pub(crate) fn escape_identifier(ident: &str, client: &Client) -> String {
+    let quote = client.quote_char();
+    let trimmed = ident.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::with_capacity(trimmed.len() + 4);
+    for (i, part) in trimmed.split('.').enumerate() {
+        if i > 0 {
+            out.push('.');
+        }
+        let part = part.trim();
+        if part == "*" {
+            out.push('*');
+            continue;
+        }
+        out.push(quote);
+        for ch in part.chars() {
+            if ch == quote {
+                // Double the quote char to embed it safely.
+                out.push(quote);
+            }
+            out.push(ch);
+        }
+        out.push(quote);
+    }
+    out
+}
+
+/// Escape each identifier in a list and join them with `, `.
+pub(crate) fn escape_identifier_list(idents: &[String], client: &Client) -> String {
+    idents
+        .iter()
+        .map(|ident| escape_identifier(ident, client))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_identifier_mysql() {
+        assert_eq!(escape_identifier("name", &Client::Mysql), "`name`");
+    }
+
+    #[test]
+    fn qualified_identifier_mysql() {
+        assert_eq!(
+            escape_identifier("users.name", &Client::Mysql),
+            "`users`.`name`"
+        );
+    }
+
+    #[test]
+    fn wildcard_passthrough() {
+        assert_eq!(escape_identifier("*", &Client::Mysql), "*");
+        assert_eq!(escape_identifier("users.*", &Client::Mysql), "`users`.*");
+    }
+
+    #[test]
+    fn sqlite_uses_double_quotes() {
+        assert_eq!(escape_identifier("name", &Client::Sqlite), "\"name\"");
+    }
+
+    #[test]
+    fn injection_attempt_is_neutralized_mysql() {
+        // A backtick in the input is doubled, keeping it inside one identifier.
+        assert_eq!(
+            escape_identifier("name` = 1; DROP TABLE users; -- ", &Client::Mysql),
+            "`name`` = 1; DROP TABLE users; --`"
+        );
+    }
+
+    #[test]
+    fn injection_attempt_is_neutralized_sqlite() {
+        assert_eq!(
+            escape_identifier("name\" OR \"1\"=\"1", &Client::Sqlite),
+            "\"name\"\" OR \"\"1\"\"=\"\"1\""
+        );
+    }
+
+    #[test]
+    fn empty_input_yields_empty() {
+        assert_eq!(escape_identifier("   ", &Client::Mysql), "");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 // Core modules
 mod builder;
 mod common;
+mod dialect;
 mod query;
 mod types;
 

--- a/src/mysql/mod.rs
+++ b/src/mysql/mod.rs
@@ -73,6 +73,9 @@ pub fn to_sql(chain_builder: &ChainBuilder) -> ToSql {
     let mut order_by_raw = String::new();
     let mut order_by_raw_binds: Vec<serde_json::Value> = vec![];
 
+    // Capture the dialect before the loop: the `With` arm shadows `chain_builder`.
+    let client = chain_builder.query.client.clone();
+
     for common in chain_builder.query.query_common.iter() {
         match common {
             crate::types::Common::With(alias, recursive, chain_builder) => {
@@ -86,7 +89,7 @@ pub fn to_sql(chain_builder: &ChainBuilder) -> ToSql {
                     with.push_str("RECURSIVE");
                     with.push(' ');
                 }
-                with.push_str(alias.as_str());
+                with.push_str(&crate::dialect::escape_identifier(alias, &client));
                 with.push_str(" AS (");
                 let sql = merge_to_sql(to_sql(chain_builder));
                 with.push_str(sql.0.as_str());
@@ -116,7 +119,10 @@ pub fn to_sql(chain_builder: &ChainBuilder) -> ToSql {
                 offset = Some(*o);
             }
             crate::types::Common::GroupBy(g) => {
-                group_by.extend(g.clone());
+                group_by.extend(
+                    g.iter()
+                        .map(|col| crate::dialect::escape_identifier(col, &client)),
+                );
             }
             crate::types::Common::GroupByRaw(g, b) => {
                 group_by_raw.push_str(g.as_str());
@@ -125,7 +131,11 @@ pub fn to_sql(chain_builder: &ChainBuilder) -> ToSql {
                 }
             }
             crate::types::Common::OrderBy(column, order) => {
-                order_by.push(format!("{} {}", column, order));
+                order_by.push(format!(
+                    "{} {}",
+                    crate::dialect::escape_identifier(column, &client),
+                    order
+                ));
             }
             crate::types::Common::OrderByRaw(sql, val) => {
                 order_by_raw.push_str(sql.as_str());

--- a/src/query/common.rs
+++ b/src/query/common.rs
@@ -116,6 +116,9 @@ pub trait HavingClauses {
 
 impl HavingClauses for QueryBuilder {
     fn having(&mut self, column: &str, operator: &str, value: Value) {
+        // NOTE: HAVING operands are expression-oriented (e.g. `COUNT(*)`), so the
+        // column is treated as a raw expression and is NOT identifier-escaped.
+        // Do not pass untrusted input here; use bound `value`s for data.
         let sql = format!("{} {} ?", column, operator);
         self.query_common
             .push(Common::Having(sql, Some(vec![value])));
@@ -127,6 +130,7 @@ impl HavingClauses for QueryBuilder {
     }
 
     fn having_between(&mut self, column: &str, values: [Value; 2]) {
+        // Expression-oriented; see `having` for the escaping rationale.
         let sql = format!("{} BETWEEN ? AND ?", column);
         self.query_common
             .push(Common::Having(sql, Some(values.to_vec())));
@@ -358,12 +362,15 @@ impl WhereClauses for QueryBuilder {
 
     fn where_ilike(&mut self, column: &str, value: Value) {
         // For MySQL, use LOWER() function
+        let column = crate::dialect::escape_identifier(column, &self.client);
         let sql = format!("LOWER({}) LIKE LOWER(?)", column);
         self.statement
             .push(crate::types::Statement::Raw((sql, Some(vec![value]))));
     }
 
     fn where_column(&mut self, lhs: &str, operator: &str, rhs: &str) {
+        let lhs = crate::dialect::escape_identifier(lhs, &self.client);
+        let rhs = crate::dialect::escape_identifier(rhs, &self.client);
         let sql = format!("{} {} {}", lhs, operator, rhs);
         self.statement
             .push(crate::types::Statement::Raw((sql, None)));
@@ -388,6 +395,7 @@ impl WhereClauses for QueryBuilder {
     }
 
     fn where_json_contains(&mut self, column: &str, value: Value) {
+        let column = crate::dialect::escape_identifier(column, &self.client);
         let sql = format!("JSON_CONTAINS({}, ?)", column);
         self.statement
             .push(crate::types::Statement::Raw((sql, Some(vec![value]))));

--- a/src/query/join/join_methods.rs
+++ b/src/query/join/join_methods.rs
@@ -135,7 +135,8 @@ impl JoinMethods for QueryBuilder {
     }
 
     fn join_using(&mut self, table: &str, columns: Vec<String>) {
-        let columns_str = columns.join(", ");
+        let table = crate::dialect::escape_identifier(table, &self.client);
+        let columns_str = crate::dialect::escape_identifier_list(&columns, &self.client);
         let sql = format!("JOIN {} USING ({})", table, columns_str);
         self.raw_join(&sql, None);
     }

--- a/src/sqlite/mod.rs
+++ b/src/sqlite/mod.rs
@@ -71,6 +71,9 @@ pub fn to_sql(chain_builder: &ChainBuilder) -> ToSql {
         }
     }
 
+    // Capture the dialect before the loop: the `With` arm shadows `chain_builder`.
+    let client = chain_builder.query.client.clone();
+
     // Process common clauses
     for common in chain_builder.query.query_common.iter() {
         match common {
@@ -83,7 +86,7 @@ pub fn to_sql(chain_builder: &ChainBuilder) -> ToSql {
                 if *recursive {
                     with.push_str("RECURSIVE ");
                 }
-                with.push_str(alias);
+                with.push_str(&crate::dialect::escape_identifier(alias, &client));
                 with.push_str(" AS (");
                 let sql = to_sql(chain_builder);
                 with.push_str(&sql.method.0);
@@ -110,7 +113,10 @@ pub fn to_sql(chain_builder: &ChainBuilder) -> ToSql {
                 offset = Some(*o);
             }
             crate::types::Common::GroupBy(g) => {
-                group_by.extend(g.clone());
+                group_by.extend(
+                    g.iter()
+                        .map(|col| crate::dialect::escape_identifier(col, &client)),
+                );
             }
             crate::types::Common::GroupByRaw(g, b) => {
                 group_by_raw.push_str(g.as_str());
@@ -128,7 +134,11 @@ pub fn to_sql(chain_builder: &ChainBuilder) -> ToSql {
                 }
             }
             crate::types::Common::OrderBy(column, order) => {
-                order_by.push(format!("{} {}", column, order));
+                order_by.push(format!(
+                    "{} {}",
+                    crate::dialect::escape_identifier(column, &client),
+                    order
+                ));
             }
             crate::types::Common::OrderByRaw(sql, val) => {
                 order_by_raw.push_str(sql.as_str());

--- a/tests/advanced_features_test.rs
+++ b/tests/advanced_features_test.rs
@@ -37,10 +37,10 @@ fn test_advanced_where_clauses() {
     println!("Binds: {:?}", binds);
 
     // Basic assertions
-    assert!(sql.contains("LOWER(name) LIKE LOWER(?)"));
-    assert!(sql.contains("users.age > profiles.min_age"));
+    assert!(sql.contains("LOWER(`name`) LIKE LOWER(?)"));
+    assert!(sql.contains("`users`.`age` > `profiles`.`min_age`"));
     assert!(sql.contains("EXISTS ("));
-    assert!(sql.contains("JSON_CONTAINS(metadata, ?)"));
+    assert!(sql.contains("JSON_CONTAINS(`metadata`, ?)"));
 }
 
 #[test]
@@ -65,12 +65,12 @@ fn test_aggregate_functions() {
     println!("Binds: {:?}", binds);
 
     // Basic assertions
-    assert!(sql.contains("COUNT(id)"));
-    assert!(sql.contains("SUM(amount)"));
-    assert!(sql.contains("AVG(amount)"));
-    assert!(sql.contains("MAX(created_at)"));
-    assert!(sql.contains("MIN(created_at)"));
-    assert!(sql.contains("user_id AS uid"));
+    assert!(sql.contains("COUNT(`id`)"));
+    assert!(sql.contains("SUM(`amount`)"));
+    assert!(sql.contains("AVG(`amount`)"));
+    assert!(sql.contains("MAX(`created_at`)"));
+    assert!(sql.contains("MIN(`created_at`)"));
+    assert!(sql.contains("`user_id` AS `uid`"));
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn test_advanced_joins() {
     // Basic assertions
     assert!(sql.contains("FULL OUTER JOIN"));
     assert!(sql.contains("CROSS JOIN"));
-    assert!(sql.contains("JOIN roles USING (user_id)"));
+    assert!(sql.contains("JOIN `roles` USING (`user_id`)"));
 }
 
 #[test]
@@ -162,7 +162,7 @@ fn test_select_methods() {
     // Basic assertions
     assert!(sql.contains("SELECT DISTINCT"));
     assert!(sql.contains("CONCAT(first_name, ' ', last_name) AS full_name"));
-    assert!(sql.contains("COUNT(id)"));
-    assert!(sql.contains("SUM(points)"));
-    assert!(sql.contains("created_at AS joined_at"));
+    assert!(sql.contains("COUNT(`id`)"));
+    assert!(sql.contains("SUM(`points`)"));
+    assert!(sql.contains("`created_at` AS `joined_at`"));
 }

--- a/tests/mysql_test.rs
+++ b/tests/mysql_test.rs
@@ -51,7 +51,7 @@ fn test_chain_builder() {
     // println!("final binds: {:?}", sql.1);
     assert_eq!(
             sql.0,
-            "SELECT * FROM mydb.users WHERE name = ? AND city = ? AND department IN (?,?) AND (status = ? OR (status = ? AND registered_at BETWEEN ? AND ?)) AND (latitude BETWEEN ? AND ?) AND (longitude BETWEEN ? AND ?) LIMIT ?"
+            "SELECT * FROM `mydb`.`users` WHERE `name` = ? AND `city` = ? AND `department` IN (?,?) AND (`status` = ? OR (`status` = ? AND `registered_at` BETWEEN ? AND ?)) AND (latitude BETWEEN ? AND ?) AND (longitude BETWEEN ? AND ?) LIMIT ?"
         );
     assert_eq!(
         sql.1,
@@ -100,7 +100,7 @@ fn test_join() {
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {:?}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "SELECT *, (SELECT COUNT(*) FROM `mydb`.`users` WHERE users.id = ?) AS count FROM mydb.users JOIN mydb.details ON details.id = users.d_id AND details.id_w = users.d_id_w OR (details.id_s = users.d_id_s AND details.id_w = users.d_id_w) WHERE name = ?";
+    let true_sql = "SELECT *, (SELECT COUNT(*) FROM `mydb`.`users` WHERE users.id = ?) AS count FROM `mydb`.`users` JOIN `mydb`.`details` ON `details`.`id` = `users`.`d_id` AND `details`.`id_w` = `users`.`d_id_w` OR (`details`.`id_s` = `users`.`d_id_s` AND `details`.`id_w` = `users`.`d_id_w`) WHERE `name` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -145,7 +145,7 @@ fn test_tow_join() {
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {:?}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "SELECT *, (SELECT COUNT(*) FROM `mydb`.`users` WHERE users.id = ?) AS count FROM mydb.users JOIN mydb.details ON details.id = users.d_id AND details.id_w = users.d_id_w OR (details.id_s = users.d_id_s AND details.id_w = users.d_id_w) JOIN mydb.address ON address.id = users.a_id AND address.id_w = users.a_id_w OR (address.id_s = users.a_id_s AND address.id_w = users.a_id_w) WHERE name = ?";
+    let true_sql = "SELECT *, (SELECT COUNT(*) FROM `mydb`.`users` WHERE users.id = ?) AS count FROM `mydb`.`users` JOIN `mydb`.`details` ON `details`.`id` = `users`.`d_id` AND `details`.`id_w` = `users`.`d_id_w` OR (`details`.`id_s` = `users`.`d_id_s` AND `details`.`id_w` = `users`.`d_id_w`) JOIN `mydb`.`address` ON `address`.`id` = `users`.`a_id` AND `address`.`id_w` = `users`.`a_id_w` OR (`address`.`id_s` = `users`.`a_id_s` AND `address`.`id_w` = `users`.`a_id_w`) WHERE `name` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -173,7 +173,7 @@ fn test_join_raw() {
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {:?}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "SELECT *, (SELECT COUNT(*) FROM `mydb`.`users` WHERE users.id = ?) AS count FROM mydb.users LEFT JOIN details ON details.id = users.d_id AND details.id_w = users.d_id_w OR (details.id_s = users.d_id_s AND details.id_w = users.d_id_w) WHERE name = ?";
+    let true_sql = "SELECT *, (SELECT COUNT(*) FROM `mydb`.`users` WHERE users.id = ?) AS count FROM `mydb`.`users` LEFT JOIN details ON details.id = users.d_id AND details.id_w = users.d_id_w OR (details.id_s = users.d_id_s AND details.id_w = users.d_id_w) WHERE `name` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -190,14 +190,14 @@ fn test_insert() {
         .table("users")
         .insert(serde_json::json!({
             "name": "John",
-            "`city`": "New York",
+            "city": "New York",
             "department": "IT",
         }));
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "INSERT INTO mydb.users (`city`, department, name) VALUES (?, ?, ?)";
+    let true_sql = "INSERT INTO `mydb`.`users` (`city`, `department`, `name`) VALUES (?, ?, ?)";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -219,12 +219,12 @@ fn test_insert_many() {
         .insert_many(vec![
             serde_json::json!({
                 "name": "John",
-                "`city`": "New York",
+                "city": "New York",
                 "department": "IT",
             }),
             serde_json::json!({
                 "name": "Jane",
-                "`city`": "New York",
+                "city": "New York",
                 "department": "HR",
             }),
         ]);
@@ -232,7 +232,7 @@ fn test_insert_many() {
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "INSERT INTO mydb.users (`city`, department, name) VALUES (?, ?, ?), (?, ?, ?)";
+    let true_sql = "INSERT INTO `mydb`.`users` (`city`, `department`, `name`) VALUES (?, ?, ?), (?, ?, ?)";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -256,7 +256,7 @@ fn test_update() {
         .table("users")
         .update(serde_json::json!({
             "name": "John",
-            "`city`": "New York",
+            "city": "New York",
             "department": "IT",
         }))
         .query(|qb| {
@@ -266,7 +266,7 @@ fn test_update() {
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "UPDATE mydb.users SET `city` = ?, department = ?, name = ? WHERE id = ?";
+    let true_sql = "UPDATE `mydb`.`users` SET `city` = ?, `department` = ?, `name` = ? WHERE `id` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -294,7 +294,7 @@ fn test_delete() {
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "DELETE FROM mydb.users WHERE id = ?";
+    let true_sql = "DELETE FROM `mydb`.`users` WHERE `id` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, vec![Value::Number(1.into())]);
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -332,7 +332,7 @@ fn test_with() {
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "WITH active_users AS (SELECT *, (SELECT * FROM mydb.address WHERE city = ?) AS address FROM mydb.users WHERE status = ?) SELECT * FROM active_users WHERE name = ?";
+    let true_sql = "WITH `active_users` AS (SELECT *, (SELECT * FROM `mydb`.`address` WHERE `city` = ?) AS `address` FROM `mydb`.`users` WHERE `status` = ?) SELECT * FROM `active_users` WHERE `name` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -377,7 +377,7 @@ fn test_with_recursive() {
     let to_sqlx = builder.to_sqlx_query();
     // println!("final sql: {}", sql.0);
     // println!("final binds: {:?}", sql.1);
-    let true_sql = "WITH RECURSIVE active_users AS (SELECT *, (SELECT * FROM mydb.address WHERE city = ?) AS address FROM mydb.users WHERE status = ?) SELECT * FROM active_users WHERE name = ?";
+    let true_sql = "WITH RECURSIVE `active_users` AS (SELECT *, (SELECT * FROM `mydb`.`address` WHERE `city` = ?) AS `address` FROM `mydb`.`users` WHERE `status` = ?) SELECT * FROM `active_users` WHERE `name` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -413,7 +413,7 @@ fn test_union() {
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
     let true_sql =
-        "SELECT * FROM mydb.users WHERE name = ? UNION SELECT * FROM mydb.users WHERE status = ?";
+        "SELECT * FROM `mydb`.`users` WHERE `name` = ? UNION SELECT * FROM `mydb`.`users` WHERE `status` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -449,7 +449,7 @@ fn test_union_all() {
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
     let true_sql =
-        "SELECT * FROM mydb.users WHERE name = ? UNION ALL SELECT * FROM mydb.users WHERE status = ? UNION ALL SELECT * FROM mydb.users WHERE status = ?";
+        "SELECT * FROM `mydb`.`users` WHERE `name` = ? UNION ALL SELECT * FROM `mydb`.`users` WHERE `status` = ? UNION ALL SELECT * FROM `mydb`.`users` WHERE `status` = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -476,7 +476,7 @@ fn test_limit_offset() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users WHERE name = ? LIMIT ? OFFSET ?";
+    let true_sql = "SELECT * FROM `mydb`.`users` WHERE `name` = ? LIMIT ? OFFSET ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -504,7 +504,7 @@ fn test_group_by() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users WHERE name = ? GROUP BY name, city LIMIT ? OFFSET ?";
+    let true_sql = "SELECT * FROM `mydb`.`users` WHERE `name` = ? GROUP BY `name`, `city` LIMIT ? OFFSET ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -532,7 +532,7 @@ fn test_group_by_raw() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users WHERE name = ? GROUP BY name, city LIMIT ? OFFSET ?";
+    let true_sql = "SELECT * FROM `mydb`.`users` WHERE `name` = ? GROUP BY name, city LIMIT ? OFFSET ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -562,7 +562,7 @@ fn test_order_by() {
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
     let true_sql =
-        "SELECT * FROM mydb.users WHERE name = ? ORDER BY name ASC, city DESC LIMIT ? OFFSET ?";
+        "SELECT * FROM `mydb`.`users` WHERE `name` = ? ORDER BY `name` ASC, `city` DESC LIMIT ? OFFSET ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -590,7 +590,7 @@ fn test_order_by_raw() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users WHERE name = ? ORDER BY `count`, `name` order by (`name` is not null) desc LIMIT ? OFFSET ?";
+    let true_sql = "SELECT * FROM `mydb`.`users` WHERE `name` = ? ORDER BY `count`, `name` order by (`name` is not null) desc LIMIT ? OFFSET ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -623,7 +623,7 @@ fn test_table_raw() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM (SELECT * FROM users WHERE id = ?) as pp WHERE name = ? AND count > ? ORDER BY `count`, `name` order by (`name` is not null) desc LIMIT ? OFFSET ?";
+    let true_sql = "SELECT * FROM (SELECT * FROM users WHERE id = ?) as pp WHERE `name` = ? AND `count` > ? ORDER BY `count`, `name` order by (`name` is not null) desc LIMIT ? OFFSET ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,

--- a/tests/security_test.rs
+++ b/tests/security_test.rs
@@ -1,0 +1,99 @@
+//! Security regression tests: identifier interpolation must not allow SQL
+//! injection. Values are always bound; identifiers (columns/tables/aliases)
+//! are dialect-escaped so attacker-controlled names cannot break out.
+
+use chain_builder::{ChainBuilder, Client, JoinMethods, QueryCommon, Select, WhereClauses};
+use serde_json::Value;
+
+#[test]
+fn mysql_where_column_is_escaped() {
+    let mut builder = ChainBuilder::new(Client::Mysql);
+    builder
+        .select(Select::Columns(vec!["*".into()]))
+        .table("users")
+        .query(|qb| {
+            // A malicious "column" coming from untrusted input.
+            qb.where_eq("name`; DROP TABLE users; --", Value::String("x".to_string()));
+        });
+    let (sql, binds) = builder.to_sql();
+
+    // The injection payload is contained inside a single backtick-quoted
+    // identifier (backticks doubled); it is NOT executable SQL.
+    assert_eq!(
+        sql,
+        "SELECT * FROM `users` WHERE `name``; DROP TABLE users; --` = ?"
+    );
+    // The value is still bound, not inlined.
+    assert_eq!(binds, vec![Value::String("x".to_string())]);
+    // No unescaped statement terminator leaked into the SQL.
+    assert!(!sql.contains("; DROP TABLE users; --` = ? ;"));
+}
+
+#[test]
+fn mysql_order_by_column_is_escaped() {
+    // Classic dynamic-sort injection vector.
+    let mut builder = ChainBuilder::new(Client::Mysql);
+    builder
+        .select(Select::Columns(vec!["*".into()]))
+        .table("users")
+        .query(|qb| {
+            qb.order_by("id`; DROP TABLE users; --", "ASC");
+        });
+    let (sql, _) = builder.to_sql();
+    assert_eq!(
+        sql,
+        "SELECT * FROM `users` ORDER BY `id``; DROP TABLE users; --` ASC"
+    );
+}
+
+#[test]
+fn sqlite_identifiers_use_double_quotes() {
+    let mut builder = ChainBuilder::new(Client::Sqlite);
+    builder
+        .select(Select::Columns(vec!["id".into(), "name".into()]))
+        .table("users")
+        .query(|qb| {
+            qb.where_eq("name\" OR \"1\"=\"1", Value::String("x".to_string()));
+        });
+    let (sql, _) = builder.to_sql();
+    assert_eq!(
+        sql,
+        "SELECT \"id\", \"name\" FROM \"users\" WHERE \"name\"\" OR \"\"1\"\"=\"\"1\" = ?"
+    );
+}
+
+#[test]
+fn mysql_qualified_and_wildcard_identifiers() {
+    let mut builder = ChainBuilder::new(Client::Mysql);
+    builder
+        .db("mydb")
+        .select(Select::Columns(vec!["users.*".into()]))
+        .table("users")
+        .query(|qb| {
+            qb.left_join("profiles", |j| {
+                j.on("users.id", "=", "profiles.user_id");
+            });
+            qb.where_eq("users.status", Value::String("active".to_string()));
+        });
+    let (sql, _) = builder.to_sql();
+    assert_eq!(
+        sql,
+        "SELECT `users`.* FROM `mydb`.`users` \
+         LEFT JOIN `mydb`.`profiles` ON `users`.`id` = `profiles`.`user_id` \
+         WHERE `users`.`status` = ?"
+    );
+}
+
+#[test]
+fn mysql_insert_keys_are_escaped() {
+    let mut builder = ChainBuilder::new(Client::Mysql);
+    builder.table("users").insert(serde_json::json!({
+        "name": "John",
+        "email": "john@example.com",
+    }));
+    let (sql, _) = builder.to_sql();
+    assert_eq!(
+        sql,
+        "INSERT INTO `users` (`email`, `name`) VALUES (?, ?)"
+    );
+}

--- a/tests/sqlite_test.rs
+++ b/tests/sqlite_test.rs
@@ -18,8 +18,8 @@ fn test_sqlite_basic_select() {
     println!("SQLite SELECT SQL: {}", sql);
     println!("Binds: {:?}", binds);
 
-    assert!(sql.contains("SELECT * FROM users"));
-    assert!(sql.contains("WHERE status = ?"));
+    assert!(sql.contains("SELECT * FROM \"users\""));
+    assert!(sql.contains("WHERE \"status\" = ?"));
     assert_eq!(binds.len(), 1);
 }
 
@@ -117,7 +117,7 @@ fn test_sqlite_chain_builder() {
     let sql = builder.to_sql();
     assert_eq!(
         sql.0,
-        "SELECT * FROM mydb.users WHERE name = ? AND city = ? AND department IN (?,?) AND (status = ? OR (status = ? AND registered_at BETWEEN ? AND ?)) AND (latitude BETWEEN ? AND ?) AND (longitude BETWEEN ? AND ?) LIMIT ?"
+        "SELECT * FROM \"mydb\".\"users\" WHERE \"name\" = ? AND \"city\" = ? AND \"department\" IN (?,?) AND (\"status\" = ? OR (\"status\" = ? AND \"registered_at\" BETWEEN ? AND ?)) AND (latitude BETWEEN ? AND ?) AND (longitude BETWEEN ? AND ?) LIMIT ?"
     );
     assert_eq!(
         sql.1,
@@ -164,7 +164,7 @@ fn test_sqlite_join() {
     ));
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT *, (SELECT COUNT(*) FROM `mydb`.`users` WHERE users.id = ?) AS count FROM mydb.users JOIN mydb.details ON details.id = users.d_id AND details.id_w = users.d_id_w OR (details.id_s = users.d_id_s AND details.id_w = users.d_id_w) WHERE name = ?";
+    let true_sql = "SELECT *, (SELECT COUNT(*) FROM `mydb`.`users` WHERE users.id = ?) AS count FROM \"mydb\".\"users\" JOIN \"mydb\".\"details\" ON \"details\".\"id\" = \"users\".\"d_id\" AND \"details\".\"id_w\" = \"users\".\"d_id_w\" OR (\"details\".\"id_s\" = \"users\".\"d_id_s\" AND \"details\".\"id_w\" = \"users\".\"d_id_w\") WHERE \"name\" = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -191,7 +191,7 @@ fn test_sqlite_tow_join() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users JOIN mydb.details ON details.id = users.d_id JOIN mydb.profiles ON profiles.id = users.p_id WHERE name = ?";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" JOIN \"mydb\".\"details\" ON \"details\".\"id\" = \"users\".\"d_id\" JOIN \"mydb\".\"profiles\" ON \"profiles\".\"id\" = \"users\".\"p_id\" WHERE \"name\" = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, vec![Value::String("John".to_string())]);
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -213,7 +213,7 @@ fn test_sqlite_join_raw() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users JOIN details ON details.id = users.d_id AND details.status = ? WHERE name = ?";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" JOIN details ON details.id = users.d_id AND details.status = ? WHERE \"name\" = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -238,7 +238,7 @@ fn test_sqlite_insert() {
     println!("SQLite INSERT SQL: {}", sql);
     println!("Binds: {:?}", binds);
 
-    assert!(sql.contains("INSERT INTO users"));
+    assert!(sql.contains("INSERT INTO \"users\""));
     assert!(sql.contains("VALUES (?, ?, ?)"));
     assert_eq!(binds.len(), 3);
 }
@@ -263,7 +263,7 @@ fn test_sqlite_insert_many() {
     println!("SQLite INSERT MANY SQL: {}", sql);
     println!("Binds: {:?}", binds);
 
-    assert!(sql.contains("INSERT INTO users"));
+    assert!(sql.contains("INSERT INTO \"users\""));
     assert!(sql.contains("VALUES (?, ?, ?), (?, ?, ?)"));
     assert_eq!(binds.len(), 6);
 }
@@ -285,10 +285,10 @@ fn test_sqlite_update() {
     println!("SQLite UPDATE SQL: {}", sql);
     println!("Binds: {:?}", binds);
 
-    assert!(sql.contains("UPDATE users SET"));
-    assert!(sql.contains("status = ?"));
-    assert!(sql.contains("updated_at = ?"));
-    assert!(sql.contains("WHERE id = ?"));
+    assert!(sql.contains("UPDATE \"users\" SET"));
+    assert!(sql.contains("\"status\" = ?"));
+    assert!(sql.contains("\"updated_at\" = ?"));
+    assert!(sql.contains("WHERE \"id\" = ?"));
     assert_eq!(binds.len(), 3);
 }
 
@@ -303,8 +303,8 @@ fn test_sqlite_delete() {
     println!("SQLite DELETE SQL: {}", sql);
     println!("Binds: {:?}", binds);
 
-    assert!(sql.contains("DELETE FROM users"));
-    assert!(sql.contains("WHERE status = ?"));
+    assert!(sql.contains("DELETE FROM \"users\""));
+    assert!(sql.contains("WHERE \"status\" = ?"));
     assert_eq!(binds.len(), 1);
 }
 
@@ -338,7 +338,7 @@ fn test_sqlite_with() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "WITH active_users AS (SELECT *, (SELECT * FROM mydb.address WHERE city = ?) AS address FROM mydb.users)SELECT * FROM active_users WHERE name = ?";
+    let true_sql = "WITH \"active_users\" AS (SELECT *, (SELECT * FROM \"mydb\".\"address\" WHERE \"city\" = ?) AS \"address\" FROM \"mydb\".\"users\")SELECT * FROM \"active_users\" WHERE \"name\" = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -380,7 +380,7 @@ fn test_sqlite_with_recursive() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "WITH RECURSIVE active_users AS (SELECT *, (SELECT * FROM mydb.address WHERE city = ?) AS address FROM mydb.users)SELECT * FROM active_users WHERE name = ?";
+    let true_sql = "WITH RECURSIVE \"active_users\" AS (SELECT *, (SELECT * FROM \"mydb\".\"address\" WHERE \"city\" = ?) AS \"address\" FROM \"mydb\".\"users\")SELECT * FROM \"active_users\" WHERE \"name\" = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -414,7 +414,7 @@ fn test_sqlite_union() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users WHERE name = ? UNION SELECT * FROM mydb.users";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" WHERE \"name\" = ? UNION SELECT * FROM \"mydb\".\"users\"";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, vec![Value::String("John".to_string()),]);
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -442,7 +442,7 @@ fn test_sqlite_union_all() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users WHERE name = ? UNION ALL SELECT * FROM mydb.users";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" WHERE \"name\" = ? UNION ALL SELECT * FROM \"mydb\".\"users\"";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, vec![Value::String("John".to_string()),]);
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -461,7 +461,7 @@ fn test_sqlite_limit_offset() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users LIMIT 20, 10";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" LIMIT 20, 10";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, Vec::<Value>::new());
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -479,7 +479,7 @@ fn test_sqlite_group_by() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users GROUP BY department, status";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" GROUP BY \"department\", \"status\"";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, Vec::<Value>::new());
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -497,7 +497,7 @@ fn test_sqlite_group_by_raw() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users GROUP BY department, status";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" GROUP BY department, status";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, Vec::<Value>::new());
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -516,7 +516,7 @@ fn test_sqlite_order_by() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users ORDER BY name ASC, age DESC";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" ORDER BY \"name\" ASC, \"age\" DESC";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, Vec::<Value>::new());
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -534,7 +534,7 @@ fn test_sqlite_order_by_raw() {
         });
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
-    let true_sql = "SELECT * FROM mydb.users ORDER BY name ASC, age DESC";
+    let true_sql = "SELECT * FROM \"mydb\".\"users\" ORDER BY name ASC, age DESC";
     assert_eq!(sql.0, true_sql);
     assert_eq!(sql.1, Vec::<Value>::new());
     assert_eq!(to_sqlx.sql(), true_sql);
@@ -556,7 +556,7 @@ fn test_sqlite_table_raw() {
     let sql = builder.to_sql();
     let to_sqlx = builder.to_sqlx_query();
     let true_sql =
-        "SELECT * FROM (SELECT * FROM users WHERE status = ?) as active_users WHERE name = ?";
+        "SELECT * FROM (SELECT * FROM users WHERE status = ?) as active_users WHERE \"name\" = ?";
     assert_eq!(sql.0, true_sql);
     assert_eq!(
         sql.1,
@@ -588,9 +588,9 @@ fn test_sqlite_joins() {
     println!("SQLite JOIN SQL: {}", sql);
     println!("Binds: {:?}", binds);
 
-    assert!(sql.contains("SELECT users.name, profiles.bio FROM users"));
-    assert!(sql.contains("LEFT JOIN profiles ON users.id = profiles.user_id"));
-    assert!(sql.contains("WHERE users.status = ?"));
+    assert!(sql.contains("SELECT \"users\".\"name\", \"profiles\".\"bio\" FROM \"users\""));
+    assert!(sql.contains("LEFT JOIN \"profiles\" ON \"users\".\"id\" = \"profiles\".\"user_id\""));
+    assert!(sql.contains("WHERE \"users\".\"status\" = ?"));
 }
 
 #[test]
@@ -610,8 +610,8 @@ fn test_sqlite_aggregate_functions() {
     println!("SQLite Aggregate SQL: {}", sql);
     println!("Binds: {:?}", binds);
 
-    assert!(sql.contains("SELECT COUNT(id), SUM(amount), AVG(amount) FROM orders"));
-    assert!(sql.contains("GROUP BY user_id"));
+    assert!(sql.contains("SELECT COUNT(\"id\"), SUM(\"amount\"), AVG(\"amount\") FROM \"orders\""));
+    assert!(sql.contains("GROUP BY \"user_id\""));
     assert!(sql.contains("HAVING COUNT(*) > ?"));
 }
 
@@ -657,8 +657,8 @@ fn test_sqlite_with_cte() {
     println!("SQLite CTE SQL: {}", sql);
     println!("Binds: {:?}", binds);
 
-    assert!(sql.contains("WITH active_users AS ("));
-    assert!(sql.contains("SELECT * FROM active_users"));
+    assert!(sql.contains("WITH \"active_users\" AS ("));
+    assert!(sql.contains("SELECT * FROM \"active_users\""));
 }
 
 #[test]
@@ -685,5 +685,5 @@ fn test_sqlite_union_old() {
     println!("Binds: {:?}", binds);
 
     assert!(sql.contains("UNION"));
-    assert!(sql.contains("SELECT * FROM users"));
+    assert!(sql.contains("SELECT * FROM \"users\""));
 }


### PR DESCRIPTION
## Summary
Closes the **identifier** axis of SQL injection. Values were already bound (`?`); identifiers (table/column/alias names) were interpolated verbatim, so an attacker-controlled name (e.g. a dynamic `ORDER BY` column from a request) could break out of the identifier context.

## Changes
- Add `src/dialect.rs` — dialect-aware `escape_identifier` (MySQL backticks, SQLite/Postgres double quotes; embedded quote chars doubled; `db.table.col` escaped per segment; `*` preserved) + unit tests.
- Escape identifiers across the structured API: `WHERE`/`SELECT` columns, `[db.]table` refs + aliases, `INSERT`/`UPDATE` keys, `GROUP BY` / `ORDER BY` columns, `JOIN` tables/aliases/`ON` columns, CTE aliases, `where_column`/`where_ilike`/`where_json_contains`/`join_using`, and the `select_count/sum/avg/max/min/alias` helpers.
- Raw/expression methods (`*_raw`, `table_raw`, `raw_join`, `on_raw`, `having*`) remain verbatim escape hatches by design.
- **DoS hardening**: `insert_many` no longer indexes `data[0]` (empty-set panic); `insert`/`insert_many`/`update` bind `NULL` for missing values instead of panicking; debug `println!` calls removed.
- `tests/security_test.rs` (injection-neutralization regression tests) + updated existing expectations for the now-quoted SQL.
- README "Security" section + CHANGELOG.

## ⚠️ Breaking change
Generated SQL now quotes identifiers. Pass **bare** names (`"name"`, not `` "`name`" ``) — pre-quoting would be double-escaped. Update any tests asserting exact unquoted SQL.

## Verification
- `cargo test --features dev-dependencies` → 63 pass
- No new clippy warnings; builds clean on all feature combos

🤖 Generated with [Claude Code](https://claude.com/claude-code)