### PR TITLE
👷 Add crates.io publish workflow (RUST_TOKEN)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish to crates.io
+
+# Publishes the crate to crates.io.
+#
+# Triggers:
+#   - Pushing a version tag (e.g. `v1.0.2`) — the tag must match the version in
+#     Cargo.toml, otherwise the job fails before publishing.
+#   - Manually via the "Run workflow" button (workflow_dispatch).
+#
+# Auth: uses `RUST_TOKEN` (a crates.io API token) provided as an
+# *Organization* secret. The organization secret must grant access to this
+# repository (Org Settings → Secrets and variables → Actions → RUST_TOKEN →
+# Repository access).
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Test & publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --features dev-dependencies --no-fail-fast
+
+      - name: Verify tag matches Cargo.toml version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          CARGO_VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          echo "Cargo.toml version: $CARGO_VERSION"
+          echo "Git tag version:    $TAG_VERSION"
+          if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag '$TAG_VERSION' does not match Cargo.toml version '$CARGO_VERSION'"
+            exit 1
+          fi
+
+      - name: Package (dry-run check)
+        run: cargo publish --dry-run
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.RUST_TOKEN }}
+        run: cargo publish


### PR DESCRIPTION
## Summary
Adds `.github/workflows/publish.yml` to publish the crate to **crates.io**.

## Behavior
- **Triggers**: push of a `v*` tag (e.g. `v1.0.2`), or manual `workflow_dispatch`.
- Runs `cargo test --features dev-dependencies`.
- On tag pushes, verifies the git tag matches the `Cargo.toml` version (fails otherwise).
- `cargo publish --dry-run` packaging check, then `cargo publish`.
- Auth via `CARGO_REGISTRY_TOKEN` sourced from the **`RUST_TOKEN` organization secret**.

## Required setup
The org secret `RUST_TOKEN` (a crates.io API token) must grant this repo access:
Org Settings → Secrets and variables → Actions → `RUST_TOKEN` → Repository access.

## Security
No untrusted `github.event.*` inputs are used in `run:` steps; the token is passed via `env:`.

## How to release
```
# bump version in Cargo.toml, commit, then:
git tag v1.0.2 && git push origin v1.0.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)