### PR TITLE
🔖 Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.2] - 2026-06-09
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "chain-builder"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "chain-builder",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-builder"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "A query builder for MySQL for Rust is designed to be flexible and easy to use."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-chain-builder = "1.0.0"
+chain-builder = "1.0.2"
 serde_json = "1.0"
 ```
 
@@ -36,7 +36,7 @@ For MySQL with sqlx integration:
 
 ```toml
 [dependencies]
-chain-builder = { version = "1.0.0", features = ["sqlx_mysql"] }
+chain-builder = { version = "1.0.2", features = ["sqlx_mysql"] }
 sqlx = { version = "0.8", features = ["mysql", "runtime-tokio-rustls"] }
 ```
 
@@ -44,7 +44,7 @@ For SQLite with sqlx integration:
 
 ```toml
 [dependencies]
-chain-builder = { version = "1.0.0", features = ["sqlx_sqlite"] }
+chain-builder = { version = "1.0.2", features = ["sqlx_sqlite"] }
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-rustls"] }
 ```
 
@@ -52,7 +52,7 @@ For both MySQL and SQLite with sqlx integration:
 
 ```toml
 [dependencies]
-chain-builder = { version = "1.0.0", features = ["sqlx_mysql", "sqlx_sqlite"] }
+chain-builder = { version = "1.0.2", features = ["sqlx_mysql", "sqlx_sqlite"] }
 sqlx = { version = "0.8", features = ["mysql", "sqlite", "runtime-tokio-rustls"] }
 ```
 


### PR DESCRIPTION
## Summary
Cuts **1.0.2**, finalizing the Unreleased changes:
- sqlx **0.8 → 0.9** upgrade
- SQL **identifier escaping** (injection hardening) + DoS hardening

## Version bumps
- `Cargo.toml` + `Cargo.lock`: `1.0.1` → `1.0.2`
- README install pins: `1.0.0` → `1.0.2`
- `CHANGELOG.md`: `[Unreleased]` → `[1.0.2] - 2026-06-09`

## Pre-flight (mirrors publish.yml gates)
- `cargo test --features dev-dependencies` → 63 pass
- `cargo publish --dry-run` → packaged 31 files, compiles clean
- sqlite-only build → ok

After merge, tag `v1.0.2` on main triggers `publish.yml` → crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)