### PR TITLE
✨ v2 M2: JOIN / CTE / UNION / GROUP BY / HAVING / ORDER BY / LIMIT

### DIFF
--- a/docs/superpowers/specs/2026-06-09-chain-builder-v2-M2-plan.md
+++ b/docs/superpowers/specs/2026-06-09-chain-builder-v2-M2-plan.md
@@ -104,6 +104,44 @@ unions:  Vec<(bool /*all*/, QueryBuilder<D>)>,
   bind → assert exact `$1`(cte) `$2`(main) `$3`(union) ordering and the bind vec
   matches; mysql/sqlite `?` equivalents; `WITH RECURSIVE`.
 
+## Plan-review fixes (decisions — implementers MUST follow)
+
+- **`_raw` Postgres `$N` contract (B1/OQ4/F3).** `having_raw` and `on_raw` are
+  verbatim escape hatches that inherit the exact `where_raw` limitation: for
+  Postgres the caller writes literal `$N` and is responsible for the offset (the
+  bind position = `binds.len()` at emit time, which in a CTE/UNION composition is
+  only known at compile time). Give `having_raw`/`on_raw` the SAME `/// Warning`
+  doc block as `where_raw`. The CTE→main→UNION acceptance test MUST use only
+  **structured** predicates (no pg-numbered `_raw`) so it doesn't depend on caller
+  offset arithmetic.
+- **OFFSET requires LIMIT (F2).** MySQL rejects bare `OFFSET`. Decision: in
+  `compile_into`, if `offset.is_some() && limit.is_none()` → `panic!("offset(...)
+  requires limit(...)")` (uniform across dialects). Document on `offset()`.
+- **CTE single-pass emission (F1).** The `ctes` loop writes each CTE's name header
+  AND compiles its body (`compile_into`) in ONE pass per CTE, so SQL text order ==
+  bind-push order (placeholder/bind never desync).
+- **`having(col,op,val)` vs `having_raw` (F3).** `having` escapes `col` (a real
+  column/alias → `"col" > ?`); aggregate expressions like `COUNT(*)` use
+  `having_raw`. Document this split (mirrors `where_raw`).
+- **Non-SELECT + M2 clauses (F5).** joins/groups/havings/orders/limit/offset/ctes/
+  unions render ONLY for `Method::Select`. For INSERT/UPDATE/DELETE they are
+  ignored (not rendered) — document; no panic.
+- **`JoinCond` enum (OQ1).** `enum JoinCond { On(String,&'static str,String),
+  OnVal(String,&'static str,Value), OnRaw(String,Vec<Value>) }` in one
+  `Vec<JoinCond>` per `Join`. (Cols in `On`/`OnVal` stored raw, escaped in
+  compile.)
+- **GROUP BY / ORDER BY dotted idents (OQ2).** `esc()` is already dotted-path
+  aware (`escape_identifier` splits on `.`), so `group_by(["t.col"])` →
+  `"t"."col"` correctly. GROUP BY of **expressions** (e.g. `YEAR(d)`) is out of
+  M2 scope (a `group_by_raw` is deferred) — document.
+- **CROSS JOIN (OQ5).** `cross_join(table)` takes **no** ON closure (CROSS JOIN
+  has no ON) — sidesteps the "conditions on a cross join" ambiguity entirely.
+- **Struct initializer (B2).** Add all new fields to `QueryBuilder::table()`'s
+  `Self { … }` initializer (mechanical; caught at first `cargo check`).
+- **Baseline note.** Pre-existing 1.x `fmt`/`clippy -D warnings` drift is NOT in
+  scope; run v2-scoped checks only (`clippy --features v2 | grep src/v2`), and
+  `cargo fmt` only `src/v2/` + new tests.
+
 ## Out of M2 (deferred)
 
 `DISTINCT ON`/jsonb/ILIKE (M5), upsert+RETURNING (M3), typed fetch (M4),

--- a/docs/superpowers/specs/2026-06-09-chain-builder-v2-M2-plan.md
+++ b/docs/superpowers/specs/2026-06-09-chain-builder-v2-M2-plan.md
@@ -1,0 +1,122 @@
+# chain-builder v2 — M2 plan: JOIN / CTE / UNION / GROUP BY / HAVING / ORDER BY
+
+Spec: `2026-06-09-chain-builder-v2-query-builder-design.md` (Milestone M2) · Base:
+`d313031` (branch `feat/v2-m2`, off `v2`) · TDD throughout · all under
+`feature = "v2"`; 1.x untouched.
+
+## Goal
+
+Port the remaining 1.x SELECT-shaping clauses onto the generic `QueryBuilder<D>`:
+JOINs, CTEs (`WITH` / `WITH RECURSIVE`), `UNION` / `UNION ALL`, `GROUP BY`,
+`HAVING`, `ORDER BY`, `LIMIT` / `OFFSET` — with **placeholder continuity** (pg
+`$1..$n` in first-appearance order) across nested sub-queries.
+
+## Foundational refactor (M2-T1, do first)
+
+The current `compile.rs::compile<D>(qb) -> (String, Vec<Value>)` allocates a fresh
+`Ctx` each call, so a nested sub-query (CTE body, UNION arm) would restart pg
+placeholder numbering at `$1`. Refactor to thread one `Ctx`:
+
+```rust
+struct Ctx { sql: String, binds: Vec<Value>, quote: char }
+impl Ctx {
+    fn esc(&self, ident: &str) -> String { escape_identifier(ident, self.quote) }
+    fn placeholder<D: Dialect>(&mut self, v: Value) {
+        self.binds.push(v); D::write_placeholder(&mut self.sql, self.binds.len());
+    }
+}
+/// Write `qb`'s SQL into an existing ctx (binds + placeholder counter continue).
+fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) { … }
+/// Public entry: fresh ctx → compile_into → (sql, binds).
+pub fn compile<D: Dialect>(qb: &QueryBuilder<D>) -> (String, Vec<Value>) { … }
+```
+
+`quote` lives on `Ctx` (set from `D::quote_char()` once). All existing `esc(col,
+quote)` sites become `ctx.esc(col)`. **Behavior must be byte-identical** for every
+existing M1 test (run the full M1 suite — must stay green unchanged).
+
+Statement assembly order inside `compile_into` (SELECT):
+`[WITH ctes] SELECT cols FROM table [JOINs] [WHERE] [GROUP BY] [HAVING] [ORDER BY]
+[LIMIT] [OFFSET] [UNION arms]`. INSERT/UPDATE/DELETE unchanged (no joins/group/etc
+in M2).
+
+## Builder additions (`QueryBuilder<D>` new fields, all raw-stored)
+
+```rust
+joins:   Vec<Join>,                       // Join { kind: JoinKind, table: String, on: Vec<JoinCond> }
+groups:  Vec<String>,                     // raw col idents
+havings: Vec<Having>,                     // Having::Expr{sql,binds} | Having::Col{col,op,val}
+orders:  Vec<(String, Order)>,            // (raw col, Asc|Desc)
+limit:   Option<i64>, offset: Option<i64>,
+ctes:    Vec<Cte<D>>,                     // Cte { name: String, recursive: bool, query: QueryBuilder<D> }
+unions:  Vec<(bool /*all*/, QueryBuilder<D>)>,
+```
+(`Vec<QueryBuilder<D>>` provides the heap indirection — no `Box` needed.)
+
+## M2-T1 — refactor + ORDER BY / GROUP BY / LIMIT / OFFSET
+
+- Refactor as above.
+- `order_by(col, Order)` (enum `Order { Asc, Desc }`) and `order_by_asc/desc(col)`
+  convenience; render `ORDER BY {esc col} ASC|DESC, …`.
+- `group_by<I: IntoIterator<Item=impl AsRef<str>>>(cols)`; render
+  `GROUP BY {esc c}, …`.
+- `limit(n: i64)`, `offset(n: i64)`; render `LIMIT ` + placeholder, `OFFSET ` +
+  placeholder (bound as `Value::I64`, uniform across pg/mysql/sqlite — pg gets
+  `$n`). **Decision:** bind limit/offset (not inline) for injection-uniformity.
+- Tests `tests/v2_clauses.rs`: per-dialect ORDER BY (asc+desc), GROUP BY (dotted +
+  multi), LIMIT+OFFSET placeholder numbering after a WHERE (pg: WHERE `$1` →
+  LIMIT `$2` OFFSET `$3`).
+
+## M2-T2 — JOINs
+
+- `enum JoinKind { Inner, Left, Right, FullOuter, Cross }` → keywords
+  `INNER JOIN`/`LEFT JOIN`/`RIGHT JOIN`/`FULL OUTER JOIN`/`CROSS JOIN`.
+- Builder: `join(table, |j| …)`, `left_join`, `right_join`, `full_outer_join`,
+  `cross_join`. Closure gets a `JoinClause` exposing `on(col, op, col2)` (both
+  idents escaped), `on_val(col, op, impl IntoBind)` (col escaped, value bound),
+  `on_raw(sql, Vec<Value>)` (verbatim). Multiple `on` joined by `AND`.
+- Render: `{KIND} {esc table} ON {cond AND cond}` (CROSS JOIN emits no `ON` if
+  no conds). Placeholders from `on_val` continue the counter.
+- Tests: pg/mysql/sqlite inner+left join with `on`; `on_val` placeholder ordering
+  relative to WHERE; dotted table+cols escaped.
+
+## M2-T3 — HAVING
+
+- `having(col, op, impl IntoBind)` → escapes `col`, binds value: `{esc col} {op}
+  {ph}`.
+- `having_raw(sql, Vec<Value>)` → verbatim expression (for `COUNT(*) > ?`),
+  documented escape hatch. Multiple HAVING joined by `AND`.
+- Render after GROUP BY: `HAVING …`.
+- Tests: `having_raw("COUNT(*) > ?", …)` + `having("total", ">", …)` per dialect;
+  placeholder continuity GROUP BY has none, so HAVING `$n` continues from WHERE.
+
+## M2-T4 — CTE (WITH) + UNION
+
+- `with(name, query)`, `with_recursive(name, query)` → push `Cte`. Render
+  `WITH [RECURSIVE] {esc name} AS ({sub}), … ` BEFORE the main SELECT, compiling
+  each sub via `compile_into` so binds/placeholders continue (CTE binds appear
+  first → pg numbers them `$1..` before the main query's). If any cte is
+  recursive, the single `WITH` carries `RECURSIVE` (SQL: `WITH RECURSIVE a AS
+  (...), b AS (...)`).
+- `union(query)`, `union_all(query)` → push `(all, query)`. Render after the main
+  query: ` UNION [ALL] {sub}` per arm, via `compile_into` (placeholders continue).
+- Tests (the crux): pg statement with a CTE bind + main WHERE bind + UNION-arm
+  bind → assert exact `$1`(cte) `$2`(main) `$3`(union) ordering and the bind vec
+  matches; mysql/sqlite `?` equivalents; `WITH RECURSIVE`.
+
+## Out of M2 (deferred)
+
+`DISTINCT ON`/jsonb/ILIKE (M5), upsert+RETURNING (M3), typed fetch (M4),
+when/modify+pagination helpers (M6), lateral joins, `UNION` of differing dialects
+(N/A — same `D`).
+
+## Acceptance
+
+- M1 suite green **unchanged** after the refactor (byte-identical SQL).
+- New `tests/v2_clauses.rs` + `tests/v2_join.rs` + `tests/v2_cte_union.rs` pass for
+  pg (default+`sqlx_postgres`), mysql, sqlite (isolated `--no-default-features`).
+- Per single sqlx backend (1.x multi-sqlx limitation): `cargo test --features
+  v2,sqlx_postgres`, `…,sqlx_mysql`, `--no-default-features …,v2,sqlite,sqlx_sqlite`.
+- 1.x baseline still **63**; no new `src/v2` clippy warnings.
+- **Placeholder continuity across CTE→main→UNION verified** (pg `$1..$n` first
+  appearance) — the load-bearing invariant.

--- a/src/v2/builder.rs
+++ b/src/v2/builder.rs
@@ -20,6 +20,135 @@ pub enum Order {
     Desc,
 }
 
+/// The kind of SQL `JOIN`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoinKind {
+    /// `INNER JOIN`.
+    Inner,
+    /// `LEFT JOIN`.
+    Left,
+    /// `RIGHT JOIN`.
+    Right,
+    /// `FULL OUTER JOIN`.
+    FullOuter,
+    /// `CROSS JOIN` (no `ON`).
+    Cross,
+}
+
+/// A single `ON` condition of a [`Join`].
+///
+/// Columns in `On`/`OnVal` are stored raw and escaped at compile time. `OnRaw`
+/// is the verbatim escape hatch (see [`JoinClause::on_raw`]).
+#[derive(Debug, Clone, PartialEq)]
+pub enum JoinCond {
+    /// `lhs op rhs` — both sides are columns (escaped at compile time).
+    On(String, &'static str, String),
+    /// `col op ?` — `col` escaped, the value is bound.
+    OnVal(String, &'static str, Value),
+    /// Verbatim SQL with its own binds.
+    OnRaw(String, Vec<Value>),
+}
+
+/// A `JOIN` clause: a kind, a target table, and zero or more `ON` conditions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Join {
+    /// The join kind (`INNER`, `LEFT`, …).
+    pub kind: JoinKind,
+    /// Raw target table identifier (escaped at compile time).
+    pub table: String,
+    /// `ON` conditions, joined by `AND`. Empty for `CROSS JOIN`.
+    pub on: Vec<JoinCond>,
+}
+
+/// A `HAVING` condition (SELECT-only, rendered after `GROUP BY`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Having {
+    /// `col op ?` — `col` is a real column/alias (escaped); value bound.
+    Col {
+        /// Raw column identifier (escaped at compile time).
+        col: String,
+        /// SQL operator token (`>`, `=`, …).
+        op: String,
+        /// Bound value.
+        val: Value,
+    },
+    /// Verbatim aggregate expression with its own binds (e.g. `COUNT(*) > ?`).
+    Raw {
+        /// Verbatim SQL.
+        sql: String,
+        /// Bound values appended in order.
+        binds: Vec<Value>,
+    },
+}
+
+/// A common table expression (`WITH` / `WITH RECURSIVE`).
+pub struct Cte<D: Dialect> {
+    /// Raw CTE name (escaped at compile time).
+    pub name: String,
+    /// Whether this CTE forces the single `WITH` to carry `RECURSIVE`.
+    pub recursive: bool,
+    /// The sub-query compiled into the CTE body.
+    pub query: QueryBuilder<D>,
+}
+
+/// Accumulator passed to `join`/`left_join`/… closures to build `ON` conditions.
+///
+/// The closure receives an empty `JoinClause`, chains `on`/`on_val`/`on_raw`
+/// calls, and returns it; the builder stores the collected conditions.
+pub struct JoinClause<D: Dialect> {
+    conds: Vec<JoinCond>,
+    _marker: PhantomData<D>,
+}
+
+impl<D: Dialect> Default for JoinClause<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<D: Dialect> JoinClause<D> {
+    /// Create an empty accumulator.
+    pub fn new() -> Self {
+        Self {
+            conds: Vec::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    fn into_conds(self) -> Vec<JoinCond> {
+        self.conds
+    }
+
+    /// `lhs op rhs` — both sides are columns (each escaped at compile time).
+    pub fn on(mut self, col: &str, op: &'static str, col2: &str) -> Self {
+        self.conds
+            .push(JoinCond::On(col.to_owned(), op, col2.to_owned()));
+        self
+    }
+
+    /// `col op ?` — `col` escaped, the value bound as a placeholder.
+    pub fn on_val(mut self, col: &str, op: &'static str, val: impl IntoBind) -> Self {
+        self.conds
+            .push(JoinCond::OnVal(col.to_owned(), op, val.into_bind()));
+        self
+    }
+
+    /// Raw `ON` SQL fragment with its own binds — the verbatim escape hatch.
+    ///
+    /// # Warning: positional placeholder contract
+    ///
+    /// `sql` is emitted **verbatim** (it is NOT escaped or renumbered) and
+    /// `binds` are appended to the running bind list in order. For
+    /// **Postgres**, the caller MUST write `$N` numbers matching the actual
+    /// bind position — that is, `number of binds already accumulated + 1`, `+2`,
+    /// … For MySQL/SQLite use `?`. No renumbering is performed, so a wrong `$N`
+    /// produces a malformed query.
+    pub fn on_raw(mut self, sql: &str, binds: Vec<Value>) -> Self {
+        self.conds.push(JoinCond::OnRaw(sql.to_owned(), binds));
+        self
+    }
+}
+
 /// Which kind of statement is being built.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Method {
@@ -41,10 +170,14 @@ pub struct QueryBuilder<D: Dialect> {
     pub(crate) wheres: Vec<Predicate>,
     pub(crate) method: Method,
     pub(crate) set: Vec<(String, Value)>,
+    pub(crate) joins: Vec<Join>,
     pub(crate) groups: Vec<String>,
+    pub(crate) havings: Vec<Having>,
     pub(crate) orders: Vec<(String, Order)>,
     pub(crate) limit: Option<i64>,
     pub(crate) offset: Option<i64>,
+    pub(crate) ctes: Vec<Cte<D>>,
+    pub(crate) unions: Vec<(bool, QueryBuilder<D>)>,
     _marker: PhantomData<D>,
 }
 
@@ -57,10 +190,14 @@ impl<D: Dialect> QueryBuilder<D> {
             wheres: Vec::new(),
             method: Method::Select,
             set: Vec::new(),
+            joins: Vec::new(),
             groups: Vec::new(),
+            havings: Vec::new(),
             orders: Vec::new(),
             limit: None,
             offset: None,
+            ctes: Vec::new(),
+            unions: Vec::new(),
             _marker: PhantomData,
         }
     }
@@ -282,6 +419,127 @@ impl<D: Dialect> QueryBuilder<D> {
     /// rejects a bare `OFFSET`.
     pub fn offset(mut self, n: i64) -> Self {
         self.offset = Some(n);
+        self
+    }
+
+    fn push_join(
+        mut self,
+        kind: JoinKind,
+        table: &str,
+        f: impl FnOnce(JoinClause<D>) -> JoinClause<D>,
+    ) -> Self {
+        let on = f(JoinClause::new()).into_conds();
+        self.joins.push(Join {
+            kind,
+            table: table.to_owned(),
+            on,
+        });
+        self
+    }
+
+    /// `INNER JOIN table ON …` — conditions built by the closure.
+    ///
+    /// SELECT-only: ignored for INSERT/UPDATE/DELETE.
+    pub fn join(self, table: &str, f: impl FnOnce(JoinClause<D>) -> JoinClause<D>) -> Self {
+        self.push_join(JoinKind::Inner, table, f)
+    }
+
+    /// `LEFT JOIN table ON …`. SELECT-only.
+    pub fn left_join(self, table: &str, f: impl FnOnce(JoinClause<D>) -> JoinClause<D>) -> Self {
+        self.push_join(JoinKind::Left, table, f)
+    }
+
+    /// `RIGHT JOIN table ON …`. SELECT-only.
+    pub fn right_join(self, table: &str, f: impl FnOnce(JoinClause<D>) -> JoinClause<D>) -> Self {
+        self.push_join(JoinKind::Right, table, f)
+    }
+
+    /// `FULL OUTER JOIN table ON …`. SELECT-only.
+    pub fn full_outer_join(
+        self,
+        table: &str,
+        f: impl FnOnce(JoinClause<D>) -> JoinClause<D>,
+    ) -> Self {
+        self.push_join(JoinKind::FullOuter, table, f)
+    }
+
+    /// `CROSS JOIN table` — takes **no** `ON` closure (a cross join has no
+    /// condition). SELECT-only.
+    pub fn cross_join(mut self, table: &str) -> Self {
+        self.joins.push(Join {
+            kind: JoinKind::Cross,
+            table: table.to_owned(),
+            on: Vec::new(),
+        });
+        self
+    }
+
+    /// `HAVING col op ?` — `col` is a real column/alias (escaped); value bound.
+    ///
+    /// For aggregate expressions like `COUNT(*) > ?`, use [`Self::having_raw`].
+    /// SELECT-only: ignored for INSERT/UPDATE/DELETE. Multiple HAVING terms are
+    /// joined by `AND`.
+    pub fn having(mut self, col: &str, op: &str, val: impl IntoBind) -> Self {
+        self.havings.push(Having::Col {
+            col: col.to_owned(),
+            op: op.to_owned(),
+            val: val.into_bind(),
+        });
+        self
+    }
+
+    /// Raw `HAVING` expression with its own binds — the verbatim escape hatch
+    /// for aggregates (e.g. `having_raw("COUNT(*) > ?", …)`).
+    ///
+    /// # Warning: positional placeholder contract
+    ///
+    /// `sql` is emitted **verbatim** (it is NOT escaped or renumbered) and
+    /// `binds` are appended to the running bind list in order. For
+    /// **Postgres**, the caller MUST write `$N` numbers matching the actual
+    /// bind position — that is, `number of binds already accumulated + 1`, `+2`,
+    /// … For MySQL/SQLite use `?`. No renumbering is performed, so a wrong `$N`
+    /// produces a malformed query.
+    pub fn having_raw(mut self, sql: &str, binds: Vec<Value>) -> Self {
+        self.havings.push(Having::Raw {
+            sql: sql.to_owned(),
+            binds,
+        });
+        self
+    }
+
+    /// Add a `WITH name AS (query)` common table expression. SELECT-only.
+    ///
+    /// CTE bodies are compiled before the main query, so their binds (and pg
+    /// `$N` numbers) appear first.
+    pub fn with(mut self, name: &str, query: QueryBuilder<D>) -> Self {
+        self.ctes.push(Cte {
+            name: name.to_owned(),
+            recursive: false,
+            query,
+        });
+        self
+    }
+
+    /// Add a recursive CTE. If any CTE is recursive, the single `WITH` carries
+    /// `RECURSIVE`. SELECT-only.
+    pub fn with_recursive(mut self, name: &str, query: QueryBuilder<D>) -> Self {
+        self.ctes.push(Cte {
+            name: name.to_owned(),
+            recursive: true,
+            query,
+        });
+        self
+    }
+
+    /// Append a `UNION query` arm. SELECT-only.
+    pub fn union(mut self, query: QueryBuilder<D>) -> Self {
+        self.unions.push((false, query));
+        self
+    }
+
+    /// Append a `UNION ALL query` arm. SELECT-only.
+    pub fn union_all(mut self, query: QueryBuilder<D>) -> Self {
+        self.unions.push((true, query));
         self
     }
 

--- a/src/v2/builder.rs
+++ b/src/v2/builder.rs
@@ -11,6 +11,15 @@ use crate::v2::dialect::Dialect;
 use crate::v2::value::{IntoBind, Value};
 use crate::v2::where_::{Conj, Predicate, WhereBuilder};
 
+/// Sort direction for an `ORDER BY` column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Order {
+    /// Ascending (`ASC`).
+    Asc,
+    /// Descending (`DESC`).
+    Desc,
+}
+
 /// Which kind of statement is being built.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Method {
@@ -32,6 +41,10 @@ pub struct QueryBuilder<D: Dialect> {
     pub(crate) wheres: Vec<Predicate>,
     pub(crate) method: Method,
     pub(crate) set: Vec<(String, Value)>,
+    pub(crate) groups: Vec<String>,
+    pub(crate) orders: Vec<(String, Order)>,
+    pub(crate) limit: Option<i64>,
+    pub(crate) offset: Option<i64>,
     _marker: PhantomData<D>,
 }
 
@@ -44,6 +57,10 @@ impl<D: Dialect> QueryBuilder<D> {
             wheres: Vec::new(),
             method: Method::Select,
             set: Vec::new(),
+            groups: Vec::new(),
+            orders: Vec::new(),
+            limit: None,
+            offset: None,
             _marker: PhantomData,
         }
     }
@@ -220,6 +237,51 @@ impl<D: Dialect> QueryBuilder<D> {
     /// Build a `DELETE`. WHERE still applies.
     pub fn delete(mut self) -> Self {
         self.method = Method::Delete;
+        self
+    }
+
+    /// Add `GROUP BY` columns (raw owned identifiers, escaped at compile time).
+    ///
+    /// SELECT-only: ignored for INSERT/UPDATE/DELETE.
+    pub fn group_by<I, S>(mut self, cols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.groups
+            .extend(cols.into_iter().map(|c| c.as_ref().to_owned()));
+        self
+    }
+
+    /// Add an `ORDER BY col <ord>` term. SELECT-only.
+    pub fn order_by(mut self, col: &str, ord: Order) -> Self {
+        self.orders.push((col.to_owned(), ord));
+        self
+    }
+
+    /// Add an `ORDER BY col ASC` term. SELECT-only.
+    pub fn order_by_asc(self, col: &str) -> Self {
+        self.order_by(col, Order::Asc)
+    }
+
+    /// Add an `ORDER BY col DESC` term. SELECT-only.
+    pub fn order_by_desc(self, col: &str) -> Self {
+        self.order_by(col, Order::Desc)
+    }
+
+    /// Set `LIMIT n` (bound as a placeholder). SELECT-only.
+    pub fn limit(mut self, n: i64) -> Self {
+        self.limit = Some(n);
+        self
+    }
+
+    /// Set `OFFSET n` (bound as a placeholder). SELECT-only.
+    ///
+    /// `offset` requires `limit`: compiling an offset without a limit panics
+    /// (`offset(...) requires limit(...)`), uniform across dialects since MySQL
+    /// rejects a bare `OFFSET`.
+    pub fn offset(mut self, n: i64) -> Self {
+        self.offset = Some(n);
         self
     }
 

--- a/src/v2/compile.rs
+++ b/src/v2/compile.rs
@@ -5,7 +5,7 @@
 //! counter, so Postgres yields `$1..$n` in first-appearance order (including
 //! across nested groups) while MySQL/SQLite yield `?`.
 
-use crate::v2::builder::{Method, Order, QueryBuilder};
+use crate::v2::builder::{Cte, Having, Join, JoinCond, JoinKind, Method, Order, QueryBuilder};
 use crate::v2::dialect::Dialect;
 use crate::v2::ident::escape_identifier;
 use crate::v2::value::Value;
@@ -61,6 +61,8 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
 
     match qb.method {
         Method::Select => {
+            // CTEs are emitted first so their binds (and pg `$N`) come first.
+            write_ctes::<D>(ctx, &qb.ctes);
             ctx.sql.push_str("SELECT ");
             if qb.select_cols.is_empty() {
                 ctx.sql.push('*');
@@ -70,10 +72,13 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             }
             ctx.sql.push_str(" FROM ");
             ctx.sql.push_str(&table);
+            write_joins::<D>(ctx, &qb.joins);
             write_wheres::<D>(ctx, &qb.wheres);
             write_group_by(ctx, &qb.groups);
+            write_having::<D>(ctx, &qb.havings);
             write_order_by(ctx, &qb.orders);
             write_limit_offset::<D>(ctx, qb.limit, qb.offset);
+            write_unions::<D>(ctx, &qb.unions);
         }
         Method::Insert => {
             if qb.set.is_empty() {
@@ -131,6 +136,119 @@ fn write_group_by(ctx: &mut Ctx, groups: &[String]) {
     ctx.sql.push_str(" GROUP BY ");
     let cols: Vec<String> = groups.iter().map(|c| ctx.esc(c)).collect();
     ctx.sql.push_str(&cols.join(", "));
+}
+
+/// Render each `JOIN` (SELECT only): ` {KIND} {esc table}[ ON cond AND …]`.
+/// `CROSS JOIN` emits no `ON`. Placeholders from `OnVal`/`OnRaw` continue the
+/// running counter.
+fn write_joins<D: Dialect>(ctx: &mut Ctx, joins: &[Join]) {
+    for j in joins {
+        let kw = match j.kind {
+            JoinKind::Inner => " INNER JOIN ",
+            JoinKind::Left => " LEFT JOIN ",
+            JoinKind::Right => " RIGHT JOIN ",
+            JoinKind::FullOuter => " FULL OUTER JOIN ",
+            JoinKind::Cross => " CROSS JOIN ",
+        };
+        ctx.sql.push_str(kw);
+        let table = ctx.esc(&j.table);
+        ctx.sql.push_str(&table);
+        if j.on.is_empty() {
+            continue;
+        }
+        ctx.sql.push_str(" ON ");
+        for (i, cond) in j.on.iter().enumerate() {
+            if i > 0 {
+                ctx.sql.push_str(" AND ");
+            }
+            match cond {
+                JoinCond::On(c, op, c2) => {
+                    let l = ctx.esc(c);
+                    let r = ctx.esc(c2);
+                    ctx.sql.push_str(&l);
+                    ctx.sql.push(' ');
+                    ctx.sql.push_str(op);
+                    ctx.sql.push(' ');
+                    ctx.sql.push_str(&r);
+                }
+                JoinCond::OnVal(c, op, v) => {
+                    let l = ctx.esc(c);
+                    ctx.sql.push_str(&l);
+                    ctx.sql.push(' ');
+                    ctx.sql.push_str(op);
+                    ctx.sql.push(' ');
+                    ctx.placeholder::<D>(v.clone());
+                }
+                JoinCond::OnRaw(sql, binds) => {
+                    // Verbatim escape hatch (see `JoinClause::on_raw` docs).
+                    ctx.sql.push_str(sql);
+                    ctx.binds.extend(binds.iter().cloned());
+                }
+            }
+        }
+    }
+}
+
+/// Render ` HAVING cond AND …` (SELECT only) after GROUP BY. No-op when empty.
+fn write_having<D: Dialect>(ctx: &mut Ctx, havings: &[Having]) {
+    if havings.is_empty() {
+        return;
+    }
+    ctx.sql.push_str(" HAVING ");
+    for (i, h) in havings.iter().enumerate() {
+        if i > 0 {
+            ctx.sql.push_str(" AND ");
+        }
+        match h {
+            Having::Col { col, op, val } => {
+                let c = ctx.esc(col);
+                ctx.sql.push_str(&c);
+                ctx.sql.push(' ');
+                ctx.sql.push_str(op);
+                ctx.sql.push(' ');
+                ctx.placeholder::<D>(val.clone());
+            }
+            Having::Raw { sql, binds } => {
+                // Verbatim escape hatch (see `having_raw` docs).
+                ctx.sql.push_str(sql);
+                ctx.binds.extend(binds.iter().cloned());
+            }
+        }
+    }
+}
+
+/// Render `WITH [RECURSIVE] name AS (body), … ` BEFORE the main SELECT.
+///
+/// Single-pass per CTE: the name header is written and the body compiled in one
+/// go, so SQL text order equals bind-push order (placeholder/bind never desync).
+fn write_ctes<D: Dialect>(ctx: &mut Ctx, ctes: &[Cte<D>]) {
+    if ctes.is_empty() {
+        return;
+    }
+    ctx.sql.push_str("WITH ");
+    if ctes.iter().any(|c| c.recursive) {
+        ctx.sql.push_str("RECURSIVE ");
+    }
+    for (i, cte) in ctes.iter().enumerate() {
+        if i > 0 {
+            ctx.sql.push_str(", ");
+        }
+        let name = ctx.esc(&cte.name);
+        ctx.sql.push_str(&name);
+        ctx.sql.push_str(" AS (");
+        compile_into::<D>(ctx, &cte.query);
+        ctx.sql.push(')');
+    }
+    ctx.sql.push(' ');
+}
+
+/// Render ` UNION [ALL] body` per arm, AFTER the main query (SELECT only).
+fn write_unions<D: Dialect>(ctx: &mut Ctx, unions: &[(bool, QueryBuilder<D>)]) {
+    for (all, arm) in unions {
+        ctx.sql
+            .push_str(if *all { " UNION ALL " } else { " UNION " });
+        compile_into::<D>(ctx, arm);
+    }
 }
 
 /// Render `ORDER BY a ASC, b DESC, …` (SELECT only). No-op when empty.

--- a/src/v2/compile.rs
+++ b/src/v2/compile.rs
@@ -5,24 +5,18 @@
 //! counter, so Postgres yields `$1..$n` in first-appearance order (including
 //! across nested groups) while MySQL/SQLite yield `?`.
 
-use crate::v2::builder::{Method, QueryBuilder};
+use crate::v2::builder::{Method, Order, QueryBuilder};
 use crate::v2::dialect::Dialect;
 use crate::v2::ident::escape_identifier;
 use crate::v2::value::Value;
 use crate::v2::where_::{Conj, Predicate};
 
-/// Escape a single identifier for SQL output.
-///
-/// This is the ONLY place identifiers are turned into SQL in v2. Every
-/// identifier→SQL site in this module routes through `esc`, so
-/// `grep 'esc(' src/v2/compile.rs` is the complete inventory of identifier
-/// writes. (The sole exception is [`Predicate::Raw`], which is the documented
-/// verbatim escape hatch and is emitted unescaped.)
-fn esc(ident: &str, quote: char) -> String {
-    escape_identifier(ident, quote)
-}
-
 /// Accumulates the generated SQL and the ordered bind values.
+///
+/// A single `Ctx` is threaded through the whole compilation (see
+/// [`compile_into`]): SQL, binds, and the placeholder counter all continue
+/// across every clause and across nested builders, which is what guarantees
+/// Postgres placeholder continuity (e.g. WHERE `$1` → LIMIT `$2` → OFFSET `$3`).
 struct Ctx {
     sql: String,
     binds: Vec<Value>,
@@ -30,26 +24,40 @@ struct Ctx {
 }
 
 impl Ctx {
-    fn new(quote: char) -> Self {
-        Self {
-            sql: String::new(),
-            binds: Vec::new(),
-            quote,
-        }
-    }
-
     /// Push a value and emit its placeholder (1-based = len after push).
     fn placeholder<D: Dialect>(&mut self, val: Value) {
         self.binds.push(val);
         D::write_placeholder(&mut self.sql, self.binds.len());
     }
+
+    /// Escape a single identifier for SQL output.
+    ///
+    /// This is the ONLY place identifiers are turned into SQL in v2. Every
+    /// identifier→SQL site in this module routes through `ctx.esc`, so
+    /// `grep 'esc(' src/v2/compile.rs` is the complete inventory of identifier
+    /// writes. (The sole exception is [`Predicate::Raw`], which is the
+    /// documented verbatim escape hatch and is emitted unescaped.)
+    fn esc(&self, ident: &str) -> String {
+        escape_identifier(ident, self.quote)
+    }
 }
 
 /// Compile a [`QueryBuilder`] into `(sql, binds)`.
 pub fn compile<D: Dialect>(qb: &QueryBuilder<D>) -> (String, Vec<Value>) {
-    let quote = D::quote_char();
-    let mut ctx = Ctx::new(quote);
-    let table = esc(&qb.table, quote);
+    let mut ctx = Ctx {
+        sql: String::new(),
+        binds: Vec::new(),
+        quote: D::quote_char(),
+    };
+    compile_into::<D>(&mut ctx, qb);
+    (ctx.sql, ctx.binds)
+}
+
+/// Write `qb`'s SQL into the existing `ctx`, continuing its binds and
+/// placeholder counter. This is the single-pass core used by [`compile`] (and,
+/// in later M2 tasks, by nested builders such as CTEs/UNION arms).
+fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
+    let table = ctx.esc(&qb.table);
 
     match qb.method {
         Method::Select => {
@@ -57,13 +65,15 @@ pub fn compile<D: Dialect>(qb: &QueryBuilder<D>) -> (String, Vec<Value>) {
             if qb.select_cols.is_empty() {
                 ctx.sql.push('*');
             } else {
-                let cols: Vec<String> =
-                    qb.select_cols.iter().map(|c| esc(c, quote)).collect();
+                let cols: Vec<String> = qb.select_cols.iter().map(|c| ctx.esc(c)).collect();
                 ctx.sql.push_str(&cols.join(", "));
             }
             ctx.sql.push_str(" FROM ");
             ctx.sql.push_str(&table);
-            write_wheres::<D>(&mut ctx, &qb.wheres);
+            write_wheres::<D>(ctx, &qb.wheres);
+            write_group_by(ctx, &qb.groups);
+            write_order_by(ctx, &qb.orders);
+            write_limit_offset::<D>(ctx, qb.limit, qb.offset);
         }
         Method::Insert => {
             if qb.set.is_empty() {
@@ -74,7 +84,7 @@ pub fn compile<D: Dialect>(qb: &QueryBuilder<D>) -> (String, Vec<Value>) {
             ctx.sql.push_str("INSERT INTO ");
             ctx.sql.push_str(&table);
             ctx.sql.push_str(" (");
-            let cols: Vec<String> = rows.iter().map(|(k, _)| esc(k, quote)).collect();
+            let cols: Vec<String> = rows.iter().map(|(k, _)| ctx.esc(k)).collect();
             ctx.sql.push_str(&cols.join(", "));
             ctx.sql.push_str(") VALUES (");
             for (i, (_, v)) in rows.iter().enumerate() {
@@ -98,20 +108,66 @@ pub fn compile<D: Dialect>(qb: &QueryBuilder<D>) -> (String, Vec<Value>) {
                 if i > 0 {
                     ctx.sql.push_str(", ");
                 }
-                ctx.sql.push_str(&esc(k, quote));
+                let col = ctx.esc(k);
+                ctx.sql.push_str(&col);
                 ctx.sql.push_str(" = ");
                 ctx.placeholder::<D>(v.clone());
             }
-            write_wheres::<D>(&mut ctx, &qb.wheres);
+            write_wheres::<D>(ctx, &qb.wheres);
         }
         Method::Delete => {
             ctx.sql.push_str("DELETE FROM ");
             ctx.sql.push_str(&table);
-            write_wheres::<D>(&mut ctx, &qb.wheres);
+            write_wheres::<D>(ctx, &qb.wheres);
         }
     }
+}
 
-    (ctx.sql, ctx.binds)
+/// Render `GROUP BY a, b, …` (SELECT only). No-op when there are no columns.
+fn write_group_by(ctx: &mut Ctx, groups: &[String]) {
+    if groups.is_empty() {
+        return;
+    }
+    ctx.sql.push_str(" GROUP BY ");
+    let cols: Vec<String> = groups.iter().map(|c| ctx.esc(c)).collect();
+    ctx.sql.push_str(&cols.join(", "));
+}
+
+/// Render `ORDER BY a ASC, b DESC, …` (SELECT only). No-op when empty.
+fn write_order_by(ctx: &mut Ctx, orders: &[(String, Order)]) {
+    if orders.is_empty() {
+        return;
+    }
+    ctx.sql.push_str(" ORDER BY ");
+    let cols: Vec<String> = orders
+        .iter()
+        .map(|(c, o)| {
+            let dir = match o {
+                Order::Asc => "ASC",
+                Order::Desc => "DESC",
+            };
+            format!("{} {}", ctx.esc(c), dir)
+        })
+        .collect();
+    ctx.sql.push_str(&cols.join(", "));
+}
+
+/// Render `LIMIT $n [OFFSET $m]` (SELECT only), binding both values.
+///
+/// Panics if `offset` is set without `limit` (uniform across dialects; MySQL
+/// rejects bare `OFFSET`).
+fn write_limit_offset<D: Dialect>(ctx: &mut Ctx, limit: Option<i64>, offset: Option<i64>) {
+    if offset.is_some() && limit.is_none() {
+        panic!("offset(...) requires limit(...)");
+    }
+    if let Some(n) = limit {
+        ctx.sql.push_str(" LIMIT ");
+        ctx.placeholder::<D>(Value::I64(n));
+    }
+    if let Some(n) = offset {
+        ctx.sql.push_str(" OFFSET ");
+        ctx.placeholder::<D>(Value::I64(n));
+    }
 }
 
 /// A predicate produces no SQL if it is an empty group (F4): an empty group
@@ -172,7 +228,8 @@ fn write_preds<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate], conj: Conj) {
 fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate) {
     match pred {
         Predicate::Binary { col, op, val } => {
-            ctx.sql.push_str(&esc(col, ctx.quote));
+            let col = ctx.esc(col);
+            ctx.sql.push_str(&col);
             ctx.sql.push(' ');
             ctx.sql.push_str(op);
             ctx.sql.push(' ');
@@ -184,7 +241,8 @@ fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate) {
                 ctx.sql.push_str(if *neg { "1 = 1" } else { "1 = 0" });
                 return;
             }
-            ctx.sql.push_str(&esc(col, ctx.quote));
+            let col = ctx.esc(col);
+            ctx.sql.push_str(&col);
             ctx.sql.push_str(if *neg { " NOT IN (" } else { " IN (" });
             for (i, v) in vals.iter().enumerate() {
                 if i > 0 {
@@ -195,12 +253,14 @@ fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate) {
             ctx.sql.push(')');
         }
         Predicate::Null { col, neg } => {
-            ctx.sql.push_str(&esc(col, ctx.quote));
+            let col = ctx.esc(col);
+            ctx.sql.push_str(&col);
             ctx.sql
                 .push_str(if *neg { " IS NOT NULL" } else { " IS NULL" });
         }
         Predicate::Between { col, lo, hi } => {
-            ctx.sql.push_str(&esc(col, ctx.quote));
+            let col = ctx.esc(col);
+            ctx.sql.push_str(&col);
             ctx.sql.push_str(" BETWEEN ");
             ctx.placeholder::<D>(lo.clone());
             ctx.sql.push_str(" AND ");

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -8,7 +8,7 @@ pub mod compile;
 #[cfg(any(feature = "sqlx_mysql", feature = "sqlx_sqlite", feature = "sqlx_postgres"))]
 pub mod sqlx_bind;
 
-pub use builder::{Method, QueryBuilder};
+pub use builder::{Method, Order, QueryBuilder};
 pub use compile::compile;
 pub use dialect::{Dialect, MySql, Postgres, Sqlite};
 pub use value::{IntoBind, Value};

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -8,7 +8,7 @@ pub mod compile;
 #[cfg(any(feature = "sqlx_mysql", feature = "sqlx_sqlite", feature = "sqlx_postgres"))]
 pub mod sqlx_bind;
 
-pub use builder::{Method, Order, QueryBuilder};
+pub use builder::{Cte, Having, Join, JoinClause, JoinCond, JoinKind, Method, Order, QueryBuilder};
 pub use compile::compile;
 pub use dialect::{Dialect, MySql, Postgres, Sqlite};
 pub use value::{IntoBind, Value};

--- a/tests/v2_clauses.rs
+++ b/tests/v2_clauses.rs
@@ -1,0 +1,134 @@
+#![cfg(feature = "v2")]
+
+use chain_builder::v2::{MySql, Order, Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn postgres_group_order_limit_offset() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .group_by(["dept"])
+        .order_by_desc("created")
+        .limit(10)
+        .offset(20)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "status" = $1 GROUP BY "dept" ORDER BY "created" DESC LIMIT $2 OFFSET $3"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("active".into()), Value::I64(10), Value::I64(20)]
+    );
+}
+
+#[test]
+fn mysql_group_order_limit_offset() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .group_by(["dept"])
+        .order_by_desc("created")
+        .limit(10)
+        .offset(20)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        "SELECT `id` FROM `users` WHERE `status` = ? GROUP BY `dept` ORDER BY `created` DESC LIMIT ? OFFSET ?"
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("active".into()), Value::I64(10), Value::I64(20)]
+    );
+}
+
+#[test]
+fn sqlite_group_order_limit_offset() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .group_by(["dept"])
+        .order_by_desc("created")
+        .limit(10)
+        .offset(20)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "status" = ? GROUP BY "dept" ORDER BY "created" DESC LIMIT ? OFFSET ?"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("active".into()), Value::I64(10), Value::I64(20)]
+    );
+}
+
+#[test]
+fn dotted_group_col_is_escaped() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .group_by(["t.col"])
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT "id" FROM "users" GROUP BY "t"."col""#);
+}
+
+#[test]
+fn multi_col_order_asc_and_desc() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .order_by_asc("a")
+        .order_by_desc("b")
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" ORDER BY "a" ASC, "b" DESC"#
+    );
+}
+
+#[test]
+fn order_by_with_explicit_order_enum() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .order_by("a", Order::Asc)
+        .order_by("b", Order::Desc)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" ORDER BY "a" ASC, "b" DESC"#
+    );
+}
+
+#[test]
+fn multi_col_group_by() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .group_by(["a", "b"])
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT "id" FROM "users" GROUP BY "a", "b""#);
+}
+
+#[test]
+fn limit_without_offset() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .limit(5)
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT "id" FROM "users" LIMIT $1"#);
+    assert_eq!(binds, vec![Value::I64(5)]);
+}
+
+#[test]
+#[should_panic(expected = "offset(...) requires limit(...)")]
+fn offset_without_limit_panics() {
+    let _ = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .offset(5)
+        .to_sql();
+}

--- a/tests/v2_cte_union.rs
+++ b/tests/v2_cte_union.rs
@@ -1,0 +1,125 @@
+#![cfg(feature = "v2")]
+
+use chain_builder::v2::{MySql, Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn postgres_cte_main_union_placeholder_ordering() {
+    // THE CRUX: $1 (cte body) -> $2 (main where) -> $3 (union arm).
+    let cte = QueryBuilder::<Postgres>::table("logs")
+        .select(["n"])
+        .where_gt("n", 1i64);
+    let arm = QueryBuilder::<Postgres>::table("recent")
+        .select(["n"])
+        .where_lt("n", 99i64);
+
+    let (sql, binds) = QueryBuilder::<Postgres>::table("recent")
+        .with("recent", cte)
+        .select(["*"])
+        .where_gt("n", 5i64)
+        .union(arm)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"WITH "recent" AS (SELECT "n" FROM "logs" WHERE "n" > $1) SELECT * FROM "recent" WHERE "n" > $2 UNION SELECT "n" FROM "recent" WHERE "n" < $3"#
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(5), Value::I64(99)]);
+}
+
+#[test]
+fn postgres_with_recursive() {
+    let cte = QueryBuilder::<Postgres>::table("t").select(["n"]);
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("t")
+        .with_recursive("t", cte)
+        .select(["*"])
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"WITH RECURSIVE "t" AS (SELECT "n" FROM "t") SELECT * FROM "t""#
+    );
+}
+
+#[test]
+fn postgres_union_all() {
+    let arm = QueryBuilder::<Postgres>::table("b").select(["id"]);
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("a")
+        .select(["id"])
+        .union_all(arm)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "a" UNION ALL SELECT "id" FROM "b""#
+    );
+}
+
+#[test]
+fn postgres_two_binds_in_cte_and_main() {
+    let cte = QueryBuilder::<Postgres>::table("logs")
+        .select(["n"])
+        .where_gt("n", 1i64)
+        .where_lt("n", 10i64);
+
+    let (sql, binds) = QueryBuilder::<Postgres>::table("recent")
+        .with("recent", cte)
+        .select(["*"])
+        .where_gte("n", 5i64)
+        .where_lte("n", 8i64)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"WITH "recent" AS (SELECT "n" FROM "logs" WHERE "n" > $1 AND "n" < $2) SELECT * FROM "recent" WHERE "n" >= $3 AND "n" <= $4"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::I64(1), Value::I64(10), Value::I64(5), Value::I64(8)]
+    );
+}
+
+#[test]
+fn mysql_cte_union() {
+    let cte = QueryBuilder::<MySql>::table("logs")
+        .select(["n"])
+        .where_gt("n", 1i64);
+    let arm = QueryBuilder::<MySql>::table("recent")
+        .select(["n"])
+        .where_lt("n", 99i64);
+
+    let (sql, binds) = QueryBuilder::<MySql>::table("recent")
+        .with("recent", cte)
+        .select(["*"])
+        .where_gt("n", 5i64)
+        .union(arm)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        "WITH `recent` AS (SELECT `n` FROM `logs` WHERE `n` > ?) SELECT * FROM `recent` WHERE `n` > ? UNION SELECT `n` FROM `recent` WHERE `n` < ?"
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(5), Value::I64(99)]);
+}
+
+#[test]
+fn sqlite_cte_union() {
+    let cte = QueryBuilder::<Sqlite>::table("logs")
+        .select(["n"])
+        .where_gt("n", 1i64);
+    let arm = QueryBuilder::<Sqlite>::table("recent")
+        .select(["n"])
+        .where_lt("n", 99i64);
+
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("recent")
+        .with("recent", cte)
+        .select(["*"])
+        .where_gt("n", 5i64)
+        .union(arm)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"WITH "recent" AS (SELECT "n" FROM "logs" WHERE "n" > ?) SELECT * FROM "recent" WHERE "n" > ? UNION SELECT "n" FROM "recent" WHERE "n" < ?"#
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(5), Value::I64(99)]);
+}

--- a/tests/v2_join.rs
+++ b/tests/v2_join.rs
@@ -1,0 +1,141 @@
+#![cfg(feature = "v2")]
+
+use chain_builder::v2::{MySql, Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn postgres_inner_and_left_join_with_on() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["users.id"])
+        .join("orders", |j| j.on("orders.user_id", "=", "users.id"))
+        .left_join("profiles", |j| j.on("profiles.user_id", "=", "users.id"))
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "users"."id" FROM "users" INNER JOIN "orders" ON "orders"."user_id" = "users"."id" LEFT JOIN "profiles" ON "profiles"."user_id" = "users"."id""#
+    );
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn postgres_on_val_placeholder_before_where() {
+    // joins emit before where: ON $1 then WHERE $2
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .join("orders", |j| {
+            j.on("orders.user_id", "=", "users.id")
+                .on_val("orders.status", "=", "paid")
+        })
+        .where_eq("users.active", true)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" INNER JOIN "orders" ON "orders"."user_id" = "users"."id" AND "orders"."status" = $1 WHERE "users"."active" = $2"#
+    );
+    assert_eq!(binds, vec![Value::Text("paid".into()), Value::Bool(true)]);
+}
+
+#[test]
+fn mysql_inner_join() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("users")
+        .select(["id"])
+        .join("orders", |j| j.on("orders.user_id", "=", "users.id"))
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        "SELECT `id` FROM `users` INNER JOIN `orders` ON `orders`.`user_id` = `users`.`id`"
+    );
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn sqlite_left_join_with_on_val() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("users")
+        .select(["id"])
+        .left_join("orders", |j| j.on_val("orders.status", "=", "paid"))
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" LEFT JOIN "orders" ON "orders"."status" = ?"#
+    );
+    assert_eq!(binds, vec![Value::Text("paid".into())]);
+}
+
+#[test]
+fn right_and_full_outer_join() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("a")
+        .select(["id"])
+        .right_join("b", |j| j.on("b.a_id", "=", "a.id"))
+        .full_outer_join("c", |j| j.on("c.a_id", "=", "a.id"))
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "a" RIGHT JOIN "b" ON "b"."a_id" = "a"."id" FULL OUTER JOIN "c" ON "c"."a_id" = "a"."id""#
+    );
+}
+
+#[test]
+fn cross_join_has_no_on() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("a")
+        .select(["id"])
+        .cross_join("b")
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT "id" FROM "a" CROSS JOIN "b""#);
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn on_raw_is_verbatim() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("a")
+        .select(["id"])
+        .join("b", |j| {
+            j.on_raw(
+                r#""b"."a_id" = "a"."id" AND "b"."n" > $1"#,
+                vec![Value::I64(5)],
+            )
+        })
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "a" INNER JOIN "b" ON "b"."a_id" = "a"."id" AND "b"."n" > $1"#
+    );
+    assert_eq!(binds, vec![Value::I64(5)]);
+}
+
+#[test]
+fn join_with_having() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .group_by(["user_id"])
+        .having("user_id", ">", 10i64)
+        .having_raw("COUNT(*) > ?", vec![Value::I64(2)])
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "user_id" FROM "orders" GROUP BY "user_id" HAVING "user_id" > $1 AND COUNT(*) > ?"#
+    );
+    assert_eq!(binds, vec![Value::I64(10), Value::I64(2)]);
+}
+
+#[test]
+fn having_placeholder_continues_from_where() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .where_eq("active", true)
+        .group_by(["user_id"])
+        .having("total", ">", 100i64)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "user_id" FROM "orders" WHERE "active" = $1 GROUP BY "user_id" HAVING "total" > $2"#
+    );
+    assert_eq!(binds, vec![Value::Bool(true), Value::I64(100)]);
+}


### PR DESCRIPTION
## Summary
Milestone **M2** of v2 — ports the remaining SELECT-shaping clauses onto the generic `QueryBuilder<D>`. Targets the **`v2`** integration branch.

## What's in M2
- **`compile()` refactor → `compile_into(&mut Ctx, qb)`** — threads one shared `Ctx` (sql + binds + quote) so the placeholder counter continues across nested sub-queries. **M1 SQL byte-identical** (verified).
- **ORDER BY** (`order_by`/`_asc`/`_desc`, `Order` enum), **GROUP BY**, **LIMIT/OFFSET** (bound, pg `$n`; `offset` without `limit` panics — MySQL rejects bare OFFSET).
- **JOINs** — inner/left/right/full-outer/cross; `on`/`on_val`/`on_raw` conditions; `cross_join` takes no ON.
- **HAVING** — `having(col,op,val)` (escapes col) + `having_raw` (aggregate expressions like `COUNT(*) > ?`).
- **CTE** — `with`/`with_recursive` (single `WITH [RECURSIVE]`, comma-joined).
- **UNION** — `union`/`union_all`.

## Load-bearing invariant (verified)
Placeholder continuity — pg `$1..$n` in **first-appearance order across the whole statement** (`WITH` → main → `UNION`). Crux test asserts exact `$1`(cte) `$2`(main) `$3`(union) ordering + bind vector; an all-clause smoke (CTE+join+IN+group+having+order+limit+union) confirms end-to-end.

## Verification (re-run by orchestrator, per single sqlx backend)
- 1.x baseline **63** (untouched) · M1+T1 SQL byte-identical
- v2 core **137** · v2+pg **139** · v2+sqlite isolated **137** · **0** `src/v2` clippy warnings
- +24 new tests (clauses 9, join 9, cte/union 6)

## Known limitation (documented)
`*_raw` (where/having/on) are verbatim escape hatches: for **Postgres** the caller writes literal `$N` matching the bind position (the builder does not renumber raw SQL). Same contract as M1's `where_raw`. The crux/structured tests don't depend on this; only hand-written raw SQL does.

## Deferred (M3–M6)
upsert+RETURNING, typed `fetch_*`, Postgres jsonb/`DISTINCT ON`/ILIKE, `when`/`modify`+pagination, multi-row insert, `group_by_raw`, uuid/chrono/decimal binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)