### PR TITLE
✨ v2: db("name") for database-qualified tables (multi-tenant)

### DIFF
--- a/src/v2/builder.rs
+++ b/src/v2/builder.rs
@@ -166,6 +166,9 @@ pub enum Method {
 /// Typed, dialect-aware SQL query builder.
 pub struct QueryBuilder<D: Dialect> {
     pub(crate) table: String,
+    /// Optional database/schema qualifier (multi-tenant: one connection, many DBs).
+    /// When set, prefixes the main table and join tables: `"db"."table"`.
+    pub(crate) db: Option<String>,
     pub(crate) select_cols: Vec<String>,
     pub(crate) wheres: Vec<Predicate>,
     pub(crate) method: Method,
@@ -186,6 +189,7 @@ impl<D: Dialect> QueryBuilder<D> {
     pub fn table(name: &str) -> Self {
         Self {
             table: name.to_owned(),
+            db: None,
             select_cols: Vec::new(),
             wheres: Vec::new(),
             method: Method::Select,
@@ -200,6 +204,16 @@ impl<D: Dialect> QueryBuilder<D> {
             unions: Vec::new(),
             _marker: PhantomData,
         }
+    }
+
+    /// Set the database/schema qualifier (multi-tenant: one connection, many DBs).
+    ///
+    /// The name prefixes the main table and every join table, escaped per dialect:
+    /// `QueryBuilder::<Postgres>::table("users").db("mydb")` →
+    /// `… FROM "mydb"."users"`. Matches 1.x `db()`.
+    pub fn db(mut self, name: &str) -> Self {
+        self.db = Some(name.to_owned());
+        self
     }
 
     /// Restrict the selected columns. An empty list selects `*`.

--- a/src/v2/compile.rs
+++ b/src/v2/compile.rs
@@ -40,6 +40,15 @@ impl Ctx {
     fn esc(&self, ident: &str) -> String {
         escape_identifier(ident, self.quote)
     }
+
+    /// Escape a table, optionally prefixed by a database qualifier:
+    /// `Some("db")`, `"t"` → `"db"."t"`; `None` → `"t"`.
+    fn qualify(&self, db: Option<&str>, table: &str) -> String {
+        match db {
+            Some(d) => format!("{}.{}", self.esc(d), self.esc(table)),
+            None => self.esc(table),
+        }
+    }
 }
 
 /// Compile a [`QueryBuilder`] into `(sql, binds)`.
@@ -57,7 +66,7 @@ pub fn compile<D: Dialect>(qb: &QueryBuilder<D>) -> (String, Vec<Value>) {
 /// placeholder counter. This is the single-pass core used by [`compile`] (and,
 /// in later M2 tasks, by nested builders such as CTEs/UNION arms).
 fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
-    let table = ctx.esc(&qb.table);
+    let table = ctx.qualify(qb.db.as_deref(), &qb.table);
 
     match qb.method {
         Method::Select => {
@@ -72,7 +81,7 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             }
             ctx.sql.push_str(" FROM ");
             ctx.sql.push_str(&table);
-            write_joins::<D>(ctx, &qb.joins);
+            write_joins::<D>(ctx, &qb.joins, qb.db.as_deref());
             write_wheres::<D>(ctx, &qb.wheres);
             write_group_by(ctx, &qb.groups);
             write_having::<D>(ctx, &qb.havings);
@@ -141,7 +150,7 @@ fn write_group_by(ctx: &mut Ctx, groups: &[String]) {
 /// Render each `JOIN` (SELECT only): ` {KIND} {esc table}[ ON cond AND …]`.
 /// `CROSS JOIN` emits no `ON`. Placeholders from `OnVal`/`OnRaw` continue the
 /// running counter.
-fn write_joins<D: Dialect>(ctx: &mut Ctx, joins: &[Join]) {
+fn write_joins<D: Dialect>(ctx: &mut Ctx, joins: &[Join], db: Option<&str>) {
     for j in joins {
         let kw = match j.kind {
             JoinKind::Inner => " INNER JOIN ",
@@ -151,7 +160,7 @@ fn write_joins<D: Dialect>(ctx: &mut Ctx, joins: &[Join]) {
             JoinKind::Cross => " CROSS JOIN ",
         };
         ctx.sql.push_str(kw);
-        let table = ctx.esc(&j.table);
+        let table = ctx.qualify(db, &j.table);
         ctx.sql.push_str(&table);
         if j.on.is_empty() {
             continue;

--- a/tests/v2_db.rs
+++ b/tests/v2_db.rs
@@ -1,0 +1,81 @@
+//! v2: `db("name")` database-qualified tables (multi-tenant: one connection,
+//! many databases — like 1.x `db()`). The db identifier prefixes the main table
+//! AND join tables, escaped per dialect.
+#![cfg(feature = "v2")]
+
+use chain_builder::v2::{MySql, Postgres, Sqlite};
+type Pg = chain_builder::v2::QueryBuilder<Postgres>;
+type My = chain_builder::v2::QueryBuilder<MySql>;
+type Lite = chain_builder::v2::QueryBuilder<Sqlite>;
+
+#[test]
+fn postgres_db_qualifies_select_table() {
+    let (sql, binds) = Pg::table("users")
+        .db("mydb")
+        .select(["id"])
+        .where_eq("status", "active")
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "mydb"."users" WHERE "status" = $1"#
+    );
+    assert_eq!(binds.len(), 1);
+}
+
+#[test]
+fn mysql_db_qualifies_select_table() {
+    let (sql, _) = My::table("users").db("mydb").select(["id"]).to_sql();
+    assert_eq!(sql, "SELECT `id` FROM `mydb`.`users`");
+}
+
+#[test]
+fn sqlite_db_qualifies_select_table() {
+    let (sql, _) = Lite::table("users").db("mydb").select(["id"]).to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "mydb"."users""#);
+}
+
+#[test]
+fn db_qualifies_insert_update_delete() {
+    let (ins, _) = Pg::table("users").db("t1").insert([("name", "a")]).to_sql();
+    assert_eq!(ins, r#"INSERT INTO "t1"."users" ("name") VALUES ($1)"#);
+
+    let (upd, _) = Pg::table("users")
+        .db("t1")
+        .update([("name", "a")])
+        .where_eq("id", 1i64)
+        .to_sql();
+    assert_eq!(
+        upd,
+        r#"UPDATE "t1"."users" SET "name" = $1 WHERE "id" = $2"#
+    );
+
+    let (del, _) = Pg::table("users").db("t1").delete().where_eq("id", 1i64).to_sql();
+    assert_eq!(del, r#"DELETE FROM "t1"."users" WHERE "id" = $1"#);
+}
+
+#[test]
+fn db_also_prefixes_join_tables() {
+    // Matches 1.x: the builder's db prefixes join tables too (same tenant db).
+    let (sql, _) = Pg::table("users")
+        .db("mydb")
+        .select(["users.id"])
+        .left_join("profiles", |j| j.on("users.id", "=", "profiles.uid"))
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "users"."id" FROM "mydb"."users" LEFT JOIN "mydb"."profiles" ON "users"."id" = "profiles"."uid""#
+    );
+}
+
+#[test]
+fn no_db_is_unchanged() {
+    let (sql, _) = Pg::table("users").select(["id"]).to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "users""#);
+}
+
+#[test]
+fn db_identifier_is_escaped() {
+    // Injection through the db name is neutralized (quote doubled).
+    let (sql, _) = Pg::table("t").db(r#"ev"il"#).select(["x"]).to_sql();
+    assert_eq!(sql, r#"SELECT "x" FROM "ev""il"."t""#);
+}


### PR DESCRIPTION
## Summary
Adds `db("name")` to the v2 builder (parity with 1.x `db()`), for **multi-tenant setups where one connection serves many databases**. Targets the `v2` integration branch.

## Behavior
- `QueryBuilder::<Postgres>::table("users").db("mydb")` → `… FROM "mydb"."users"`.
- The db prefix qualifies the **main table AND join tables** (matches 1.x — same tenant db across the query): `LEFT JOIN "mydb"."profiles" ON …`.
- Applies to SELECT / INSERT / UPDATE / DELETE.
- Dialect-escaped (backticks for MySQL, double-quotes for pg/sqlite); the db name is injection-safe (`esc()`).
- `db` defaults to `None` → **M1/M2 SQL byte-identical** (no regression).

## Implementation
- `QueryBuilder<D>` gains `db: Option<String>` + `.db(name)` (by-value chaining).
- `compile.rs`: `Ctx::qualify(db, table)` helper used for the main table and threaded into `write_joins`.

## Verification
- New `tests/v2_db.rs`: **7 passing** (select/insert/update/delete + join prefix + no-db regression + db-identifier escaping).
- v2 core **144** · 1.x baseline **63** (untouched) · pg build clean · no `src/v2` clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)