### PR TITLE
✨ v2 M3: upsert (on_conflict) + RETURNING

### DIFF
--- a/docs/superpowers/specs/2026-06-09-chain-builder-v2-M3-plan.md
+++ b/docs/superpowers/specs/2026-06-09-chain-builder-v2-M3-plan.md
@@ -1,0 +1,115 @@
+# chain-builder v2 — M3 plan: Upsert (`on_conflict`) + `RETURNING`
+
+Spec: M3 milestone · Base: `bf208e1` (branch `feat/v2-m3`, off `v2`) · TDD ·
+`feature = "v2"`; 1.x untouched. Replaces 1.x's broken no-op `insert_ignore` /
+`insert_or_update`.
+
+## Goal
+
+Real, dialect-correct upsert and `RETURNING` on `QueryBuilder<D>` INSERT (and
+`RETURNING` on UPDATE/DELETE for pg/sqlite). No new binds are introduced by either
+feature (excluded/VALUES references + returning column lists carry no parameters),
+so placeholder ordering is unaffected.
+
+## Dialect divergence — the crux
+
+Add a capability to the `Dialect` trait so `compile` can branch without a runtime
+dialect discriminant:
+
+```rust
+pub enum UpsertStyle { OnConflict, OnDuplicateKey } // pg/sqlite vs mysql
+// on Dialect:
+fn upsert_style() -> UpsertStyle;
+```
+- `Postgres`/`Sqlite` → `OnConflict`; `MySql` → `OnDuplicateKey`.
+- `supports_returning()` already exists (pg/sqlite true, mysql false) — reuse for RETURNING.
+
+### Exact SQL per dialect (verify in plan review)
+
+INSERT base: `INSERT INTO {tbl} ({cols}) VALUES ({ph…})`.
+
+**Postgres / SQLite (`OnConflict`):**
+- merge: `… ON CONFLICT ({targets}) DO UPDATE SET {c} = EXCLUDED.{c}, …`
+  - SET list = inserted columns **minus** the conflict targets (don't re-set the
+    key). If that list is empty → emit `DO NOTHING` instead.
+  - `EXCLUDED` is uppercase (works in both pg and sqlite).
+- ignore: `… ON CONFLICT ({targets}) DO NOTHING` (if no targets → `ON CONFLICT DO
+  NOTHING`).
+- targets + SET columns are identifier-escaped.
+
+**MySQL (`OnDuplicateKey`):**
+- merge: `… ON DUPLICATE KEY UPDATE {c} = VALUES({c}), …` (SET list = all inserted
+  columns; MySQL uses its own unique key, **targets are ignored** — document).
+- ignore: emit `INSERT IGNORE INTO …` (change the INSERT keyword; do NOT append an
+  ON-clause). This is the idiomatic MySQL ignore (matches Knex).
+
+### RETURNING
+- pg/sqlite: ` RETURNING {cols}` (escaped; `["*"]` → `*`) appended to INSERT /
+  UPDATE / DELETE.
+- mysql (`supports_returning()==false`): **omitted** (no-op), documented (MySQL has
+  no RETURNING; matches Knex). No panic.
+
+## Builder API (`QueryBuilder<D>`)
+
+New fields (raw-stored): `on_conflict: Option<OnConflict>`, `returning:
+Vec<String>`.
+
+```rust
+pub struct OnConflict { pub targets: Vec<String>, pub action: ConflictAction }
+pub enum ConflictAction { DoNothing, Merge } // Merge = update non-target inserted cols
+```
+
+Methods (by-value chaining; only meaningful on INSERT):
+- `on_conflict_do_nothing<I,S>(self, targets: I) -> Self` (targets may be empty).
+- `on_conflict_merge<I,S>(self, targets: I) -> Self`.
+- `returning<I,S>(self, cols: I) -> Self` (e.g. `.returning(["id"])` /
+  `.returning(["*"])`).
+
+(Targets/cols: `I: IntoIterator<Item=S>, S: AsRef<str>`, stored owned raw.)
+
+## Compile changes (`compile.rs`)
+
+- INSERT arm: after the `VALUES (...)`:
+  - keyword: if `on_conflict == DoNothing` AND `D::upsert_style()==OnDuplicateKey`
+    → the INSERT keyword is `INSERT IGNORE INTO` (decide at the top of the arm) and
+    **no** trailing conflict clause.
+  - else render the conflict clause per `upsert_style()` + action as above.
+  - then RETURNING (if `supports_returning()` && `!returning.is_empty()`).
+- UPDATE / DELETE arms: append RETURNING (if supported & non-empty) at the end.
+- `on_conflict` on a non-INSERT method: ignored (documented; like M2 F5).
+- Use the existing sorted-key order for the SET list so it matches the inserted
+  column order (deterministic).
+
+## Tests — `tests/v2_upsert.rs`
+
+Per dialect, exact SQL:
+1. **pg merge:** `.table("users").insert([("id",1),("email","a"),("name","x")])
+   .on_conflict_merge(["id"])` →
+   `INSERT INTO "users" ("email", "id", "name") VALUES ($1, $2, $3) ON CONFLICT
+   ("id") DO UPDATE SET "email" = EXCLUDED."email", "name" = EXCLUDED."name"`
+   (note: `id` excluded from SET; binds `[a,1,x]` in sorted-key order).
+2. **pg ignore:** `.on_conflict_do_nothing(["id"])` → `… ON CONFLICT ("id") DO
+   NOTHING`.
+3. **sqlite** equivalents (`"`-quoted, `?`).
+4. **mysql merge:** `… ON DUPLICATE KEY UPDATE \`email\` = VALUES(\`email\`),
+   \`id\` = VALUES(\`id\`), \`name\` = VALUES(\`name\`)` (all cols; targets ignored).
+5. **mysql ignore:** `INSERT IGNORE INTO \`users\` (...) VALUES (...)` (no ON-clause).
+6. **pg/sqlite RETURNING:** `.insert(...).returning(["id"])` → `… RETURNING "id"`;
+   `.returning(["*"])` → `… RETURNING *`; on UPDATE and DELETE too.
+7. **mysql RETURNING omitted:** `.insert(...).returning(["id"])` → no `RETURNING`
+   in output.
+8. **merge where all cols are targets** (pg) → falls back to `DO NOTHING`.
+9. Regression: M1/M2 insert SQL unchanged when no on_conflict/returning set.
+
+## Acceptance
+- M1/M2 suites byte-identical (no conflict/returning by default).
+- New `tests/v2_upsert.rs` green per dialect (pg `--features v2,sqlx_postgres`,
+  mysql `--features v2,sqlx_mysql`, sqlite `--no-default-features
+  --features v2,sqlite,sqlx_sqlite`).
+- 1.x baseline **63**; no new `src/v2` clippy warnings.
+
+## Out of M3 (deferred)
+- `on_conflict_merge_with([(col, value)])` (update to explicit bound values, not
+  EXCLUDED) — M-later if needed.
+- Named-constraint conflict targets (`ON CONFLICT ON CONSTRAINT name`) — deferred.
+- Fetching the RETURNING rows (that's M4 typed-fetch; M3 only emits the clause).

--- a/docs/superpowers/specs/2026-06-09-chain-builder-v2-M3-plan.md
+++ b/docs/superpowers/specs/2026-06-09-chain-builder-v2-M3-plan.md
@@ -108,6 +108,46 @@ Per dialect, exact SQL:
   --features v2,sqlite,sqlx_sqlite`).
 - 1.x baseline **63**; no new `src/v2` clippy warnings.
 
+## Plan-review fixes (decisions — implementers MUST follow)
+
+- **Empty conflict target + Merge (B1/OQ5).** pg AND sqlite require a conflict
+  target for `DO UPDATE`. So for `OnConflict` style: emit `DO UPDATE SET …` ONLY
+  when `targets` is non-empty AND the SET list (inserted cols minus targets) is
+  non-empty. Otherwise emit `DO NOTHING` — `ON CONFLICT ({targets}) DO NOTHING` if
+  targets present, else bare `ON CONFLICT DO NOTHING`. (Covers both
+  empty-targets and all-cols-are-targets cases with valid SQL.)
+- **`upsert_style()` default impl (OQ1).** Add it to `Dialect` with a DEFAULT
+  `fn upsert_style() -> UpsertStyle { UpsertStyle::OnConflict }`; only `MySql`
+  overrides to `OnDuplicateKey`. (Non-breaking for any external `Dialect` impl,
+  and pg/sqlite need no override.)
+- **`RETURNING *` special-case (F4).** When emitting RETURNING / any column list
+  that may contain `*`, a `"*"` segment is pushed **unescaped** (`ctx.esc("*")`
+  would yield a quoted identifier). Reuse the existing `*`-aware path if present;
+  otherwise: `if c == "*" { push "*" } else { push ctx.esc(c) }`.
+- **SQLite RETURNING min version (B3).** Add a doc comment on `returning()` (and a
+  note in the crate-level v2 docs) that `RETURNING` requires **SQLite ≥ 3.35.0**
+  (2021) — `supports_returning()` is a compile-time dialect flag, not a runtime
+  version check.
+- **MySQL caveats (B2/F2/F3) — document on the API:**
+  - `on_conflict_merge` on MySQL emits `ON DUPLICATE KEY UPDATE c = VALUES(c)` for
+    ALL inserted columns (MySQL ignores the explicit `targets`; it uses its own
+    unique/primary keys). `VALUES()` is used for MySQL 5.7/8.x compatibility
+    (row-alias form deferred). Note: including a PK column in the insert set means
+    `pk = VALUES(pk)` appears — harmless but redundant.
+  - `on_conflict_do_nothing` on MySQL emits `INSERT IGNORE INTO …` (no ON-clause).
+    Document that `IGNORE` suppresses MORE than duplicate-key (also truncation /
+    bad-value coercion) — broader than pg/sqlite `DO NOTHING`.
+- **`EXCLUDED` casing (F1).** Emit uppercase `EXCLUDED` — it is an *unquoted,
+  case-insensitive identifier* accepted by both pg and sqlite. Do NOT escape it.
+- **INSERT-only doc (F5).** `on_conflict_*` and (for INSERT) the conflict clause
+  only render for `Method::Insert`; doc-comment that they are ignored on
+  UPDATE/DELETE. `returning` renders on INSERT/UPDATE/DELETE (pg/sqlite). Method
+  switching does NOT clear these fields (consistent with how `.insert()` doesn't
+  clear `wheres`) — intentional (OQ2). No debug_assert for MySQL-RETURNING-omit
+  (OQ3) — silent no-op, documented.
+- **Baseline.** Pre-existing 1.x `fmt`/`clippy -D warnings` drift is out of scope;
+  v2-scoped checks only.
+
 ## Out of M3 (deferred)
 - `on_conflict_merge_with([(col, value)])` (update to explicit bound values, not
   EXCLUDED) — M-later if needed.

--- a/src/v2/builder.rs
+++ b/src/v2/builder.rs
@@ -149,6 +149,30 @@ impl<D: Dialect> JoinClause<D> {
     }
 }
 
+/// What to do when an `INSERT` hits a conflict (see [`OnConflict`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictAction {
+    /// Skip the conflicting row (`DO NOTHING` / `INSERT IGNORE`).
+    DoNothing,
+    /// Update the non-target inserted columns from the proposed row
+    /// (`DO UPDATE SET … = EXCLUDED.…` / `ON DUPLICATE KEY UPDATE …`).
+    Merge,
+}
+
+/// An `ON CONFLICT` specification attached to an `INSERT`.
+///
+/// `targets` are the raw conflict-target column identifiers (escaped at compile
+/// time). They are honored by Postgres / SQLite (`OnConflict` style) and
+/// **ignored** by MySQL (`OnDuplicateKey` style), which relies on its own
+/// unique/primary keys.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OnConflict {
+    /// Raw conflict-target column identifiers.
+    pub targets: Vec<String>,
+    /// What to do on conflict.
+    pub action: ConflictAction,
+}
+
 /// Which kind of statement is being built.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Method {
@@ -181,6 +205,10 @@ pub struct QueryBuilder<D: Dialect> {
     pub(crate) offset: Option<i64>,
     pub(crate) ctes: Vec<Cte<D>>,
     pub(crate) unions: Vec<(bool, QueryBuilder<D>)>,
+    /// `ON CONFLICT` spec for `INSERT` (ignored on UPDATE/DELETE).
+    pub(crate) on_conflict: Option<OnConflict>,
+    /// `RETURNING` column list (raw; `"*"` emitted unescaped).
+    pub(crate) returning: Vec<String>,
     _marker: PhantomData<D>,
 }
 
@@ -202,6 +230,8 @@ impl<D: Dialect> QueryBuilder<D> {
             offset: None,
             ctes: Vec::new(),
             unions: Vec::new(),
+            on_conflict: None,
+            returning: Vec::new(),
             _marker: PhantomData,
         }
     }
@@ -388,6 +418,68 @@ impl<D: Dialect> QueryBuilder<D> {
     /// Build a `DELETE`. WHERE still applies.
     pub fn delete(mut self) -> Self {
         self.method = Method::Delete;
+        self
+    }
+
+    /// On conflict, skip the row (`INSERT`-only; ignored on UPDATE/DELETE).
+    ///
+    /// `targets` are the conflict-target columns (may be empty).
+    ///
+    /// - **Postgres / SQLite:** emits `ON CONFLICT ({targets}) DO NOTHING`, or
+    ///   bare `ON CONFLICT DO NOTHING` when `targets` is empty.
+    /// - **MySQL:** emits `INSERT IGNORE INTO …` (no trailing clause). Note that
+    ///   `IGNORE` suppresses *more* than duplicate-key errors (also truncation
+    ///   and bad-value coercion) — broader than pg/sqlite `DO NOTHING`.
+    pub fn on_conflict_do_nothing<I, S>(mut self, targets: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.on_conflict = Some(OnConflict {
+            targets: targets.into_iter().map(|c| c.as_ref().to_owned()).collect(),
+            action: ConflictAction::DoNothing,
+        });
+        self
+    }
+
+    /// On conflict, update the non-target inserted columns from the proposed row
+    /// (`INSERT`-only; ignored on UPDATE/DELETE).
+    ///
+    /// - **Postgres / SQLite:** emits
+    ///   `ON CONFLICT ({targets}) DO UPDATE SET {c} = EXCLUDED.{c}, …` for every
+    ///   inserted column *except* the conflict targets. If `targets` is empty or
+    ///   covers all inserted columns (empty SET list), falls back to the
+    ///   `DO NOTHING` rendering (pg/sqlite require a target for `DO UPDATE`).
+    /// - **MySQL:** the explicit `targets` are **ignored** (MySQL uses its own
+    ///   unique/primary keys); emits
+    ///   `ON DUPLICATE KEY UPDATE {c} = VALUES({c}), …` for *all* inserted
+    ///   columns. `VALUES()` is used for MySQL 5.7/8.x compatibility. Including a
+    ///   PK column in the insert set yields a redundant-but-harmless
+    ///   `pk = VALUES(pk)`.
+    pub fn on_conflict_merge<I, S>(mut self, targets: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.on_conflict = Some(OnConflict {
+            targets: targets.into_iter().map(|c| c.as_ref().to_owned()).collect(),
+            action: ConflictAction::Merge,
+        });
+        self
+    }
+
+    /// Add a `RETURNING` column list. Works on INSERT / UPDATE / DELETE for
+    /// Postgres and SQLite; a `"*"` column is emitted unescaped (`RETURNING *`).
+    ///
+    /// On **MySQL** this is a silent no-op (MySQL has no `RETURNING`). On
+    /// **SQLite** `RETURNING` requires SQLite ≥ 3.35.0 (2021); `supports_returning()`
+    /// is a compile-time dialect flag, not a runtime version check.
+    pub fn returning<I, S>(mut self, cols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.returning = cols.into_iter().map(|c| c.as_ref().to_owned()).collect();
         self
     }
 

--- a/src/v2/compile.rs
+++ b/src/v2/compile.rs
@@ -5,8 +5,10 @@
 //! counter, so Postgres yields `$1..$n` in first-appearance order (including
 //! across nested groups) while MySQL/SQLite yield `?`.
 
-use crate::v2::builder::{Cte, Having, Join, JoinCond, JoinKind, Method, Order, QueryBuilder};
-use crate::v2::dialect::Dialect;
+use crate::v2::builder::{
+    ConflictAction, Cte, Having, Join, JoinCond, JoinKind, Method, Order, QueryBuilder,
+};
+use crate::v2::dialect::{Dialect, UpsertStyle};
 use crate::v2::ident::escape_identifier;
 use crate::v2::value::Value;
 use crate::v2::where_::{Conj, Predicate};
@@ -95,7 +97,19 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             }
             let mut rows: Vec<&(String, Value)> = qb.set.iter().collect();
             rows.sort_by(|a, b| a.0.cmp(&b.0));
-            ctx.sql.push_str("INSERT INTO ");
+
+            // Decide the INSERT keyword up front: MySQL `DO NOTHING` becomes
+            // `INSERT IGNORE INTO …` with no trailing conflict clause.
+            let mysql_ignore = D::upsert_style() == UpsertStyle::OnDuplicateKey
+                && matches!(
+                    qb.on_conflict.as_ref().map(|c| c.action),
+                    Some(ConflictAction::DoNothing)
+                );
+            if mysql_ignore {
+                ctx.sql.push_str("INSERT IGNORE INTO ");
+            } else {
+                ctx.sql.push_str("INSERT INTO ");
+            }
             ctx.sql.push_str(&table);
             ctx.sql.push_str(" (");
             let cols: Vec<String> = rows.iter().map(|(k, _)| ctx.esc(k)).collect();
@@ -108,6 +122,14 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
                 ctx.placeholder::<D>(v.clone());
             }
             ctx.sql.push(')');
+
+            if !mysql_ignore {
+                if let Some(oc) = &qb.on_conflict {
+                    let inserted: Vec<&str> = rows.iter().map(|(k, _)| k.as_str()).collect();
+                    write_on_conflict::<D>(ctx, oc, &inserted);
+                }
+            }
+            write_returning::<D>(ctx, &qb.returning);
         }
         Method::Update => {
             if qb.set.is_empty() {
@@ -128,13 +150,88 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
                 ctx.placeholder::<D>(v.clone());
             }
             write_wheres::<D>(ctx, &qb.wheres);
+            write_returning::<D>(ctx, &qb.returning);
         }
         Method::Delete => {
             ctx.sql.push_str("DELETE FROM ");
             ctx.sql.push_str(&table);
             write_wheres::<D>(ctx, &qb.wheres);
+            write_returning::<D>(ctx, &qb.returning);
         }
     }
+}
+
+/// Render the upsert conflict clause for an `INSERT` (never called for the
+/// MySQL `INSERT IGNORE` path, which is handled at the keyword). `inserted` is
+/// the sorted-key list of inserted columns.
+fn write_on_conflict<D: Dialect>(
+    ctx: &mut Ctx,
+    oc: &crate::v2::builder::OnConflict,
+    inserted: &[&str],
+) {
+    match D::upsert_style() {
+        UpsertStyle::OnDuplicateKey => {
+            // MySQL merge: `ON DUPLICATE KEY UPDATE c = VALUES(c), …` for ALL
+            // inserted columns (explicit targets are ignored).
+            ctx.sql.push_str(" ON DUPLICATE KEY UPDATE ");
+            let sets: Vec<String> = inserted
+                .iter()
+                .map(|c| {
+                    let e = ctx.esc(c);
+                    format!("{e} = VALUES({e})")
+                })
+                .collect();
+            ctx.sql.push_str(&sets.join(", "));
+        }
+        UpsertStyle::OnConflict => {
+            let targets = &oc.targets;
+            // SET list = inserted columns minus the conflict targets.
+            let set_cols: Vec<&&str> = inserted
+                .iter()
+                .filter(|c| !targets.iter().any(|t| t == **c))
+                .collect();
+            let do_update = matches!(oc.action, ConflictAction::Merge)
+                && !targets.is_empty()
+                && !set_cols.is_empty();
+
+            ctx.sql.push_str(" ON CONFLICT");
+            if !targets.is_empty() {
+                ctx.sql.push_str(" (");
+                let cols: Vec<String> = targets.iter().map(|t| ctx.esc(t)).collect();
+                ctx.sql.push_str(&cols.join(", "));
+                ctx.sql.push(')');
+            }
+            if do_update {
+                ctx.sql.push_str(" DO UPDATE SET ");
+                let sets: Vec<String> = set_cols
+                    .iter()
+                    .map(|c| {
+                        let e = ctx.esc(c);
+                        // `EXCLUDED` is an unquoted, case-insensitive identifier
+                        // accepted by both pg and sqlite — emitted literally.
+                        format!("{e} = EXCLUDED.{e}")
+                    })
+                    .collect();
+                ctx.sql.push_str(&sets.join(", "));
+            } else {
+                ctx.sql.push_str(" DO NOTHING");
+            }
+        }
+    }
+}
+
+/// Render ` RETURNING col, …` when the dialect supports it and the list is
+/// non-empty. A `"*"` column is emitted unescaped. No-op otherwise (e.g. MySQL).
+fn write_returning<D: Dialect>(ctx: &mut Ctx, cols: &[String]) {
+    if !D::supports_returning() || cols.is_empty() {
+        return;
+    }
+    ctx.sql.push_str(" RETURNING ");
+    let parts: Vec<String> = cols
+        .iter()
+        .map(|c| if c == "*" { "*".to_owned() } else { ctx.esc(c) })
+        .collect();
+    ctx.sql.push_str(&parts.join(", "));
 }
 
 /// Render `GROUP BY a, b, …` (SELECT only). No-op when there are no columns.

--- a/src/v2/dialect/mod.rs
+++ b/src/v2/dialect/mod.rs
@@ -13,6 +13,18 @@ pub use mysql::MySql;
 pub use postgres::Postgres;
 pub use sqlite::Sqlite;
 
+/// How a dialect expresses an upsert (`INSERT … ON CONFLICT`).
+///
+/// Postgres and SQLite use `ON CONFLICT (...)` clauses, while MySQL uses
+/// `ON DUPLICATE KEY UPDATE` / `INSERT IGNORE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpsertStyle {
+    /// Postgres / SQLite: `ON CONFLICT (...) DO {NOTHING|UPDATE SET …}`.
+    OnConflict,
+    /// MySQL: `ON DUPLICATE KEY UPDATE …` and `INSERT IGNORE`.
+    OnDuplicateKey,
+}
+
 /// Compile-time description of a SQL dialect.
 pub trait Dialect: Sized + Send + Sync + 'static {
     /// The identifier quote character (e.g. backtick for MySQL, `"` for ANSI).
@@ -25,6 +37,13 @@ pub trait Dialect: Sized + Send + Sync + 'static {
 
     /// Whether this dialect supports the `RETURNING` clause.
     fn supports_returning() -> bool;
+
+    /// How this dialect expresses an upsert. Defaults to
+    /// [`UpsertStyle::OnConflict`] (Postgres / SQLite); MySQL overrides to
+    /// [`UpsertStyle::OnDuplicateKey`].
+    fn upsert_style() -> UpsertStyle {
+        UpsertStyle::OnConflict
+    }
 }
 
 #[cfg(test)]

--- a/src/v2/dialect/mysql.rs
+++ b/src/v2/dialect/mysql.rs
@@ -1,6 +1,6 @@
 //! MySQL dialect marker.
 
-use super::Dialect;
+use super::{Dialect, UpsertStyle};
 
 /// MySQL dialect marker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,5 +17,9 @@ impl Dialect for MySql {
 
     fn supports_returning() -> bool {
         false
+    }
+
+    fn upsert_style() -> UpsertStyle {
+        UpsertStyle::OnDuplicateKey
     }
 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -10,7 +10,8 @@ pub mod sqlx_bind;
 
 pub use builder::{Cte, Having, Join, JoinClause, JoinCond, JoinKind, Method, Order, QueryBuilder};
 pub use compile::compile;
-pub use dialect::{Dialect, MySql, Postgres, Sqlite};
+pub use dialect::{Dialect, MySql, Postgres, Sqlite, UpsertStyle};
+pub use builder::{ConflictAction, OnConflict};
 pub use value::{IntoBind, Value};
 #[cfg(any(feature = "sqlx_mysql", feature = "sqlx_sqlite", feature = "sqlx_postgres"))]
 pub use sqlx_bind::SqlxDialect;

--- a/tests/v2_upsert.rs
+++ b/tests/v2_upsert.rs
@@ -1,0 +1,211 @@
+#![cfg(feature = "v2")]
+
+use chain_builder::v2::{MySql, Postgres, QueryBuilder, Sqlite};
+
+// ----- 1. pg merge -----
+
+#[test]
+fn pg_merge() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .insert([("id", 1i64), ("email", 0), ("name", 0)]) // values irrelevant for SQL shape
+        .on_conflict_merge(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("email", "id", "name") VALUES ($1, $2, $3) ON CONFLICT ("id") DO UPDATE SET "email" = EXCLUDED."email", "name" = EXCLUDED."name""#
+    );
+}
+
+// ----- 2. pg ignore -----
+
+#[test]
+fn pg_ignore() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .insert([("id", 1i64), ("email", 0), ("name", 0)])
+        .on_conflict_do_nothing(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("email", "id", "name") VALUES ($1, $2, $3) ON CONFLICT ("id") DO NOTHING"#
+    );
+}
+
+// ----- 3. sqlite merge + ignore -----
+
+#[test]
+fn sqlite_merge() {
+    let (sql, _binds) = QueryBuilder::<Sqlite>::table("users")
+        .insert([("id", 1i64), ("email", 0), ("name", 0)])
+        .on_conflict_merge(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("email", "id", "name") VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "email" = EXCLUDED."email", "name" = EXCLUDED."name""#
+    );
+}
+
+#[test]
+fn sqlite_ignore() {
+    let (sql, _binds) = QueryBuilder::<Sqlite>::table("users")
+        .insert([("id", 1i64), ("email", 0), ("name", 0)])
+        .on_conflict_do_nothing(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("email", "id", "name") VALUES (?, ?, ?) ON CONFLICT ("id") DO NOTHING"#
+    );
+}
+
+// ----- 4. mysql merge -----
+
+#[test]
+fn mysql_merge() {
+    let (sql, _binds) = QueryBuilder::<MySql>::table("users")
+        .insert([("id", 1i64), ("email", 0), ("name", 0)])
+        .on_conflict_merge(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        "INSERT INTO `users` (`email`, `id`, `name`) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE `email` = VALUES(`email`), `id` = VALUES(`id`), `name` = VALUES(`name`)"
+    );
+}
+
+// ----- 5. mysql ignore -----
+
+#[test]
+fn mysql_ignore() {
+    let (sql, _binds) = QueryBuilder::<MySql>::table("users")
+        .insert([("id", 1i64), ("email", 0), ("name", 0)])
+        .on_conflict_do_nothing(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        "INSERT IGNORE INTO `users` (`email`, `id`, `name`) VALUES (?, ?, ?)"
+    );
+}
+
+// ----- 6. pg/sqlite RETURNING on insert/update/delete -----
+
+#[test]
+fn pg_returning_insert() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .insert([("name", "x")])
+        .returning(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("name") VALUES ($1) RETURNING "id""#
+    );
+}
+
+#[test]
+fn pg_returning_star() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .insert([("name", "x")])
+        .returning(["*"])
+        .to_sql();
+    assert_eq!(sql, r#"INSERT INTO "users" ("name") VALUES ($1) RETURNING *"#);
+}
+
+#[test]
+fn pg_returning_update() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .update([("name", "x")])
+        .where_eq("id", 1i64)
+        .returning(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "users" SET "name" = $1 WHERE "id" = $2 RETURNING "id""#
+    );
+}
+
+#[test]
+fn pg_returning_delete() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .delete()
+        .where_eq("id", 1i64)
+        .returning(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"DELETE FROM "users" WHERE "id" = $1 RETURNING "id""#
+    );
+}
+
+#[test]
+fn sqlite_returning_insert() {
+    let (sql, _binds) = QueryBuilder::<Sqlite>::table("users")
+        .insert([("name", "x")])
+        .returning(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("name") VALUES (?) RETURNING "id""#
+    );
+}
+
+// ----- 7. mysql RETURNING omitted -----
+
+#[test]
+fn mysql_returning_omitted() {
+    let (sql, _binds) = QueryBuilder::<MySql>::table("users")
+        .insert([("name", "x")])
+        .returning(["id"])
+        .to_sql();
+    assert_eq!(sql, "INSERT INTO `users` (`name`) VALUES (?)");
+    assert!(!sql.contains("RETURNING"));
+}
+
+// ----- 8. pg merge where targets cover all cols -> DO NOTHING -----
+
+#[test]
+fn pg_merge_all_cols_targets() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .insert([("id", 1i64)])
+        .on_conflict_merge(["id"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("id") VALUES ($1) ON CONFLICT ("id") DO NOTHING"#
+    );
+}
+
+// ----- 9. empty-targets merge -> bare DO NOTHING -----
+
+#[test]
+fn pg_merge_empty_targets() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .insert([("id", 1i64), ("name", 0)])
+        .on_conflict_merge(Vec::<&str>::new())
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("id", "name") VALUES ($1, $2) ON CONFLICT DO NOTHING"#
+    );
+}
+
+#[test]
+fn pg_ignore_empty_targets() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .insert([("id", 1i64), ("name", 0)])
+        .on_conflict_do_nothing(Vec::<&str>::new())
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("id", "name") VALUES ($1, $2) ON CONFLICT DO NOTHING"#
+    );
+}
+
+// ----- 10. regression: plain insert unchanged -----
+
+#[test]
+fn pg_plain_insert_unchanged() {
+    let (sql, _binds) = QueryBuilder::<Postgres>::table("users")
+        .insert([("id", 1i64), ("email", 0), ("name", 0)])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "users" ("email", "id", "name") VALUES ($1, $2, $3)"#
+    );
+}


### PR DESCRIPTION
## Summary
Milestone **M3** — real, dialect-correct **upsert** and **RETURNING**. Replaces 1.x's broken no-op `insert_ignore`/`insert_or_update`. Targets the `v2` branch. No new bind parameters → placeholder ordering untouched.

## API
- `on_conflict_merge(targets)` — update on conflict.
- `on_conflict_do_nothing(targets)` — skip on conflict.
- `returning(cols)` — e.g. `.returning(["id"])`, `.returning(["*"])`.

## Dialect-correct SQL (the crux — verified per dialect)
| | merge | ignore | RETURNING |
|---|---|---|---|
| **Postgres** | `ON CONFLICT (t) DO UPDATE SET c = EXCLUDED.c` | `ON CONFLICT (t) DO NOTHING` | `RETURNING …` |
| **SQLite** | same as pg | same as pg | `RETURNING …` (needs SQLite ≥ 3.35) |
| **MySQL** | `ON DUPLICATE KEY UPDATE c = VALUES(c)` | `INSERT IGNORE INTO …` | omitted (no RETURNING) |

- `UpsertStyle` capability added to the `Dialect` trait (default `OnConflict`; MySQL overrides) — non-breaking for external impls.
- Edge cases: empty targets or all-cols-are-targets (empty SET) → falls back to `DO NOTHING` (pg/sqlite `DO UPDATE` requires a target). `RETURNING *` emitted unescaped. SET list = inserted cols minus targets (pg/sqlite); all cols (MySQL).
- Composes with `db()` (multi-tenant) — smoke-verified.

## Verification (per single sqlx backend)
- New `tests/v2_upsert.rs`: **16 passing** (merge/ignore/returning/`*`/mysql-omit/empty-targets/all-targets/regression).
- M1/M2/db suites **byte-identical**. 1.x **63**. pg **162** · mysql **160** · sqlite **160**. No `src/v2` clippy.

## Known caveats (documented)
- MySQL `INSERT IGNORE` suppresses more than duplicate-key (also truncation/coercion) — broader than `DO NOTHING`.
- MySQL `VALUES()` chosen for 5.7/8.x compat (row-alias form deferred).

## Deferred (M4–M6)
typed `fetch_*` (incl. consuming RETURNING rows), `merge_with([(col,val)])`, named-constraint targets, jsonb/DISTINCT ON/ILIKE, when/modify+pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)