### PR TITLE
✨ v2 M4: typed fetch (execution helpers)

### DIFF
--- a/docs/superpowers/specs/2026-06-09-chain-builder-v2-M4toM7-plan.md
+++ b/docs/superpowers/specs/2026-06-09-chain-builder-v2-M4toM7-plan.md
@@ -1,0 +1,71 @@
+# chain-builder v2 — M4–M7 completion plan
+
+Base: `ef7c48f` (`v2`). Each milestone = one PR into `v2`. TDD; `feature = "v2"`;
+1.x untouched; M1–M3 SQL byte-identical (new fields default empty). Per-single-
+sqlx-backend testing (1.x multi-sqlx limitation).
+
+## M4 — Typed fetch (execution helpers)
+
+On `impl<D: SqlxDialect> QueryBuilder<D>` (in `src/v2/fetch.rs`, gated like
+`sqlx_bind`). Thin async delegations to the sqlx query objects:
+- `fetch_all::<T>(executor)`, `fetch_one::<T>(executor)`,
+  `fetch_optional::<T>(executor)` where `T: for<'r> FromRow<'r, <D::Database as
+  Database>::Row> + Send + Unpin`, `executor: Executor<'e, Database=D::Database>`.
+  → delegate to `self.to_sqlx_query_as::<T>().fetch_*`.
+- `execute(executor) -> QueryResult` → `self.to_sqlx_query().execute`.
+- `count(executor) -> i64` — wrap: `SELECT COUNT(*) FROM (<sql>) AS __c`, bind the
+  same args, `fetch_one` scalar `i64` (mirrors 1.x `count`).
+- `fetch_scalar::<T>(executor) -> T` and `fetch_optional_scalar::<T>` — first
+  column of first row (for pluck/aggregate use).
+**Tests:** compile-tests per sqlx feature — a `#[derive(sqlx::FromRow)]` row +
+an `async fn` (never run, `#[allow(dead_code)]`) that calls every helper, proving
+the generic plumbing typechecks for pg/mysql/sqlite. (Live DB integration =
+deferred to a CI/runtime task — needs a sqlx runtime feature + tokio; named, not
+hidden.)
+
+## M5 — Postgres parity extras
+
+- `distinct(self)` — `SELECT DISTINCT …` (all dialects).
+- `distinct_on(self, cols)` — pg `SELECT DISTINCT ON (cols) …`. Capability:
+  `Dialect::supports_distinct_on() -> bool` (default false; Postgres true). On a
+  dialect without it → `panic!("DISTINCT ON requires PostgreSQL")` (explicit).
+- `where_ilike(col, val)` — dialect-aware: pg `{col} ILIKE {ph}`; mysql/sqlite
+  `LOWER({col}) LIKE LOWER({ph})`. Capability `Dialect::ilike_is_native() -> bool`
+  (pg true). Add `Predicate::ILike{col,val}` (col escaped; bound val) OR build via
+  the dialect at construction. Use a `Predicate` variant so placeholder ordering
+  is correct.
+- jsonb (pg-oriented, emitted verbatim operator): `where_jsonb_contains(col, json)`
+  → `{esc col} @> {ph}` (bind json text/Value::Json). Keep minimal; advanced json
+  paths deferred.
+**Tests:** distinct/distinct_on (pg + panic on mysql), ilike per dialect,
+jsonb_contains (pg). M1–M3 unchanged.
+
+## M6 — Dynamic building + pagination
+
+- `when(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self` — apply `f` only
+  if `cond`. `when_else(cond, f_true, f_false)`.
+- `paginate(self, page: i64, per_page: i64) -> Self` — `limit(per_page)
+  .offset((page-1).max(0) * per_page)` (1-based page). Document.
+**Tests:** `when(true/false, …)` toggles a where; `paginate(2, 10)` → `LIMIT ?
+OFFSET ?` binds `[10, 10]`. Pure builder — low risk.
+
+## M7 — Fill remaining gaps
+
+- **Multi-row insert:** `insert_many<rows>(self, rows)` where a row is the same
+  `(col, val)` shape; all rows must share the first row's (sorted) key set; compile
+  `INSERT INTO t (cols) VALUES (…), (…), …`. Missing key in a later row → bind
+  `Value::Null` (no panic — DoS-safe, matches 1.x hardening). Composes with
+  on_conflict/returning.
+- **Raw group/order:** `group_by_raw(sql, binds)`, `order_by_raw(sql, binds)` —
+  verbatim (pg `$N` caller-responsibility, same Warning as `where_raw`).
+**Tests:** insert_many (single + multi-row + ragged→NULL) per dialect; group/order
+raw. M1–M3 unchanged.
+
+## Final
+- v2 module-level doc / short `docs/v2.md` usage guide (optional, time-permitting).
+- Honest wrap-up: what shipped, what's deferred (live fetch integration, uuid/
+  chrono/decimal Value variants, json path ops, named-constraint upsert targets).
+
+## Cross-cutting acceptance (every milestone)
+- M1–M3 byte-identical (no new field set by default).
+- 1.x **63**; per-backend v2 suites green; no new `src/v2` clippy.

--- a/src/v2/fetch.rs
+++ b/src/v2/fetch.rs
@@ -1,0 +1,123 @@
+//! Typed fetch / execution helpers for v2 (`feature = "sqlx_*"`).
+//!
+//! These are thin async delegations on top of the sqlx query objects already
+//! produced by [`to_sqlx_query`](QueryBuilder::to_sqlx_query) and
+//! [`to_sqlx_query_as`](QueryBuilder::to_sqlx_query_as) in
+//! [`crate::v2::sqlx_bind`]. They let any [`QueryBuilder<D>`] whose
+//! `D: SqlxDialect` run against a sqlx [`Executor`](sqlx::Executor) and decode
+//! rows into a `T: FromRow`, or pull a single scalar column.
+//!
+//! [`count`](QueryBuilder::count) mirrors 1.x `ChainBuilder::count`: it wraps the
+//! built SQL in `SELECT COUNT(*) FROM (<sql>) AS __cb_count`, binds the same
+//! arguments, and fetches a single `i64`.
+
+use crate::v2::builder::QueryBuilder;
+use crate::v2::sqlx_bind::SqlxDialect;
+
+impl<D: SqlxDialect> QueryBuilder<D> {
+    /// Fetch all rows, decoding each into `T`.
+    ///
+    /// Delegates to `self.to_sqlx_query_as::<T>().fetch_all(executor)`.
+    pub async fn fetch_all<'e, T, E>(&self, executor: E) -> Result<Vec<T>, sqlx::Error>
+    where
+        T: for<'r> sqlx::FromRow<'r, <D::Database as sqlx::Database>::Row> + Send + Unpin,
+        E: sqlx::Executor<'e, Database = D::Database>,
+    {
+        self.to_sqlx_query_as::<T>().fetch_all(executor).await
+    }
+
+    /// Fetch exactly one row, decoding it into `T`.
+    ///
+    /// Errors with [`sqlx::Error::RowNotFound`] if no row is returned.
+    pub async fn fetch_one<'e, T, E>(&self, executor: E) -> Result<T, sqlx::Error>
+    where
+        T: for<'r> sqlx::FromRow<'r, <D::Database as sqlx::Database>::Row> + Send + Unpin,
+        E: sqlx::Executor<'e, Database = D::Database>,
+    {
+        self.to_sqlx_query_as::<T>().fetch_one(executor).await
+    }
+
+    /// Fetch at most one row, decoding it into `T`.
+    pub async fn fetch_optional<'e, T, E>(
+        &self,
+        executor: E,
+    ) -> Result<Option<T>, sqlx::Error>
+    where
+        T: for<'r> sqlx::FromRow<'r, <D::Database as sqlx::Database>::Row> + Send + Unpin,
+        E: sqlx::Executor<'e, Database = D::Database>,
+    {
+        self.to_sqlx_query_as::<T>().fetch_optional(executor).await
+    }
+
+    /// Execute the query (INSERT / UPDATE / DELETE / DDL), returning the
+    /// database's `QueryResult` (affected rows, last insert id, …).
+    ///
+    /// Delegates to `self.to_sqlx_query().execute(executor)`.
+    pub async fn execute<'e, E>(
+        &self,
+        executor: E,
+    ) -> Result<<D::Database as sqlx::Database>::QueryResult, sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = D::Database>,
+    {
+        self.to_sqlx_query().execute(executor).await
+    }
+
+    /// Count the rows the query would return.
+    ///
+    /// Wraps the built SQL as `SELECT COUNT(*) FROM (<sql>) AS __cb_count`, binds
+    /// the same arguments, and fetches a single `i64`. Mirrors 1.x
+    /// `ChainBuilder::count`.
+    pub async fn count<'e, E>(&self, executor: E) -> Result<i64, sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = D::Database>,
+        // `query_scalar_with` decodes `(i64,)` from the row, which needs `i64` to
+        // be decodable for this database and a positional column index. These hold
+        // for every sqlx built-in backend but are not implied by `SqlxDialect`.
+        i64: for<'r> sqlx::Decode<'r, D::Database> + sqlx::Type<D::Database>,
+        usize: sqlx::ColumnIndex<<D::Database as sqlx::Database>::Row>,
+    {
+        let (sql, binds) = self.to_sql();
+        let wrapped = format!("SELECT COUNT(*) FROM ({sql}) AS __cb_count");
+        let args = D::bind_arguments(&binds);
+        sqlx::query_scalar_with::<D::Database, i64, _>(sqlx::AssertSqlSafe(wrapped), args)
+            .fetch_one(executor)
+            .await
+    }
+
+    /// Fetch the first column of the first row, decoded into `T`.
+    ///
+    /// Errors with [`sqlx::Error::RowNotFound`] if no row is returned. Useful for
+    /// `pluck`/aggregate-style queries.
+    pub async fn fetch_scalar<'e, T, E>(&self, executor: E) -> Result<T, sqlx::Error>
+    where
+        T: for<'r> sqlx::Decode<'r, D::Database> + sqlx::Type<D::Database> + Send + Unpin,
+        E: sqlx::Executor<'e, Database = D::Database>,
+        // `query_scalar_with` decodes `(T,)`, which requires a positional column
+        // index on the backend's row type.
+        usize: sqlx::ColumnIndex<<D::Database as sqlx::Database>::Row>,
+    {
+        let (sql, binds) = self.to_sql();
+        let args = D::bind_arguments(&binds);
+        sqlx::query_scalar_with::<D::Database, T, _>(sqlx::AssertSqlSafe(sql), args)
+            .fetch_one(executor)
+            .await
+    }
+
+    /// Fetch the first column of the first row (if any), decoded into `T`.
+    pub async fn fetch_optional_scalar<'e, T, E>(
+        &self,
+        executor: E,
+    ) -> Result<Option<T>, sqlx::Error>
+    where
+        T: for<'r> sqlx::Decode<'r, D::Database> + sqlx::Type<D::Database> + Send + Unpin,
+        E: sqlx::Executor<'e, Database = D::Database>,
+        usize: sqlx::ColumnIndex<<D::Database as sqlx::Database>::Row>,
+    {
+        let (sql, binds) = self.to_sql();
+        let args = D::bind_arguments(&binds);
+        sqlx::query_scalar_with::<D::Database, T, _>(sqlx::AssertSqlSafe(sql), args)
+            .fetch_optional(executor)
+            .await
+    }
+}

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -7,6 +7,8 @@ pub mod where_;
 pub mod compile;
 #[cfg(any(feature = "sqlx_mysql", feature = "sqlx_sqlite", feature = "sqlx_postgres"))]
 pub mod sqlx_bind;
+#[cfg(any(feature = "sqlx_mysql", feature = "sqlx_sqlite", feature = "sqlx_postgres"))]
+pub mod fetch;
 
 pub use builder::{Cte, Having, Join, JoinClause, JoinCond, JoinKind, Method, Order, QueryBuilder};
 pub use compile::compile;

--- a/tests/v2_fetch.rs
+++ b/tests/v2_fetch.rs
@@ -1,0 +1,126 @@
+//! M4 typed-fetch compile tests.
+//!
+//! These prove the generic plumbing of the `fetch_*` / `execute` / `count`
+//! helpers typechecks for each sqlx backend. They never touch a live database —
+//! the `async fn _typechecks` bodies are compiled (which is the assertion) but
+//! never run; the `#[test]` only needs to exist so the module is built under its
+//! backend feature. Live DB integration is deferred to a runtime/CI task (needs a
+//! sqlx runtime feature + an async executor).
+#![cfg(feature = "v2")]
+
+#[cfg(feature = "sqlx_postgres")]
+#[allow(dead_code)]
+mod pg {
+    use chain_builder::v2::{Postgres, QueryBuilder};
+
+    #[derive(sqlx::FromRow)]
+    struct UserRow {
+        id: i64,
+        name: String,
+    }
+
+    async fn _typechecks(pool: sqlx::PgPool) -> Result<(), sqlx::Error> {
+        let qb = QueryBuilder::<Postgres>::table("users")
+            .select(["id", "name"])
+            .where_gt("id", 0i64);
+        let rows: Vec<UserRow> = qb.fetch_all(&pool).await?;
+        let _ = rows;
+        let one: UserRow = qb.fetch_one(&pool).await?;
+        let _ = (one.id, one.name);
+        let _opt: Option<UserRow> = qb.fetch_optional(&pool).await?;
+        let _ = qb.execute(&pool).await?;
+        let _: i64 = qb.count(&pool).await?;
+        let _: i64 = QueryBuilder::<Postgres>::table("users")
+            .select(["id"])
+            .fetch_scalar(&pool)
+            .await?;
+        let _: Option<i64> = QueryBuilder::<Postgres>::table("users")
+            .select(["id"])
+            .fetch_optional_scalar(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[test]
+    fn pg_typechecks_compile() {
+        // Presence proves `_typechecks` compiled for Postgres.
+    }
+}
+
+#[cfg(feature = "sqlx_mysql")]
+#[allow(dead_code)]
+mod mysql {
+    use chain_builder::v2::{MySql, QueryBuilder};
+
+    #[derive(sqlx::FromRow)]
+    struct UserRow {
+        id: i64,
+        name: String,
+    }
+
+    async fn _typechecks(pool: sqlx::MySqlPool) -> Result<(), sqlx::Error> {
+        let qb = QueryBuilder::<MySql>::table("users")
+            .select(["id", "name"])
+            .where_gt("id", 0i64);
+        let rows: Vec<UserRow> = qb.fetch_all(&pool).await?;
+        let _ = rows;
+        let one: UserRow = qb.fetch_one(&pool).await?;
+        let _ = (one.id, one.name);
+        let _opt: Option<UserRow> = qb.fetch_optional(&pool).await?;
+        let _ = qb.execute(&pool).await?;
+        let _: i64 = qb.count(&pool).await?;
+        let _: i64 = QueryBuilder::<MySql>::table("users")
+            .select(["id"])
+            .fetch_scalar(&pool)
+            .await?;
+        let _: Option<i64> = QueryBuilder::<MySql>::table("users")
+            .select(["id"])
+            .fetch_optional_scalar(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[test]
+    fn mysql_typechecks_compile() {
+        // Presence proves `_typechecks` compiled for MySql.
+    }
+}
+
+#[cfg(feature = "sqlx_sqlite")]
+#[allow(dead_code)]
+mod sqlite {
+    use chain_builder::v2::{QueryBuilder, Sqlite};
+
+    #[derive(sqlx::FromRow)]
+    struct UserRow {
+        id: i64,
+        name: String,
+    }
+
+    async fn _typechecks(pool: sqlx::SqlitePool) -> Result<(), sqlx::Error> {
+        let qb = QueryBuilder::<Sqlite>::table("users")
+            .select(["id", "name"])
+            .where_gt("id", 0i64);
+        let rows: Vec<UserRow> = qb.fetch_all(&pool).await?;
+        let _ = rows;
+        let one: UserRow = qb.fetch_one(&pool).await?;
+        let _ = (one.id, one.name);
+        let _opt: Option<UserRow> = qb.fetch_optional(&pool).await?;
+        let _ = qb.execute(&pool).await?;
+        let _: i64 = qb.count(&pool).await?;
+        let _: i64 = QueryBuilder::<Sqlite>::table("users")
+            .select(["id"])
+            .fetch_scalar(&pool)
+            .await?;
+        let _: Option<i64> = QueryBuilder::<Sqlite>::table("users")
+            .select(["id"])
+            .fetch_optional_scalar(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[test]
+    fn sqlite_typechecks_compile() {
+        // Presence proves `_typechecks` compiled for Sqlite.
+    }
+}


### PR DESCRIPTION
## Summary
Milestone **M4** — async execution helpers so v2 returns typed results (Knex-style), on `QueryBuilder<D: SqlxDialect>`. Into `v2`.

## API (delegates to `to_sqlx_query*`)
- `fetch_all::<T>(ex)`, `fetch_one::<T>(ex)`, `fetch_optional::<T>(ex)` — `T: FromRow`.
- `execute(ex)` → `QueryResult`.
- `count(ex) -> i64` — wraps `SELECT COUNT(*) FROM (<sql>) AS __cb_count`.
- `fetch_scalar::<T>(ex)`, `fetch_optional_scalar::<T>(ex)` — first column.

## Verification
- Compile-tests per backend (`tests/v2_fetch.rs`): a `#[derive(FromRow)]` row + a never-run `async fn` calling every helper, proving the `FromRow`/`Executor`/scalar generics typecheck for pg/mysql/sqlite.
- Builds clean per backend · 1.x **63** · M1–M3 byte-identical · no `src/v2` clippy.

## Deferred (named)
Live-DB integration tests (need a sqlx runtime feature + tokio + in-memory sqlite) — a CI/runtime task, not hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)