### PR TITLE
✨ v2 M5: DISTINCT ON / ILIKE / jsonb (Postgres parity)

### DIFF
--- a/src/v2/builder.rs
+++ b/src/v2/builder.rs
@@ -194,6 +194,10 @@ pub struct QueryBuilder<D: Dialect> {
     /// When set, prefixes the main table and join tables: `"db"."table"`.
     pub(crate) db: Option<String>,
     pub(crate) select_cols: Vec<String>,
+    /// `SELECT DISTINCT` flag (raw; off by default for M1 byte-identity).
+    pub(crate) distinct: bool,
+    /// `SELECT DISTINCT ON (cols)` columns (raw; Postgres-only).
+    pub(crate) distinct_on: Vec<String>,
     pub(crate) wheres: Vec<Predicate>,
     pub(crate) method: Method,
     pub(crate) set: Vec<(String, Value)>,
@@ -219,6 +223,8 @@ impl<D: Dialect> QueryBuilder<D> {
             table: name.to_owned(),
             db: None,
             select_cols: Vec::new(),
+            distinct: false,
+            distinct_on: Vec::new(),
             wheres: Vec::new(),
             method: Method::Select,
             set: Vec::new(),
@@ -253,6 +259,54 @@ impl<D: Dialect> QueryBuilder<D> {
         S: AsRef<str>,
     {
         self.select_cols = cols.into_iter().map(|c| c.as_ref().to_owned()).collect();
+        self
+    }
+
+    /// Emit `SELECT DISTINCT …` (all dialects).
+    pub fn distinct(mut self) -> Self {
+        self.distinct = true;
+        self
+    }
+
+    /// Emit `SELECT DISTINCT ON (cols) …` — **Postgres only**.
+    ///
+    /// `cols` are raw identifiers (escaped at compile time). Compiling against a
+    /// dialect without `DISTINCT ON` support panics
+    /// (`DISTINCT ON requires PostgreSQL`).
+    pub fn distinct_on<I, S>(mut self, cols: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.distinct_on = cols.into_iter().map(|c| c.as_ref().to_owned()).collect();
+        self.distinct = true;
+        self
+    }
+
+    /// `col ILIKE val` — dialect-aware case-insensitive match.
+    ///
+    /// On **Postgres** this compiles to the native `{col} ILIKE {ph}`. On
+    /// MySQL/SQLite (no native `ILIKE`) it compiles to
+    /// `LOWER({col}) LIKE LOWER({ph})`.
+    pub fn where_ilike(mut self, col: &str, val: impl IntoBind) -> Self {
+        self.wheres.push(Predicate::ILike {
+            col: col.to_owned(),
+            val: val.into_bind(),
+        });
+        self
+    }
+
+    /// `col @> val` — JSONB containment.
+    ///
+    /// **Postgres-specific:** the `@>` operator is emitted verbatim for all
+    /// dialects, but is only meaningful on Postgres `jsonb` columns. `val` is
+    /// typically a JSON text string (or `Value::Json` behind the `json`
+    /// feature).
+    pub fn where_jsonb_contains(mut self, col: &str, val: impl IntoBind) -> Self {
+        self.wheres.push(Predicate::JsonContains {
+            col: col.to_owned(),
+            val: val.into_bind(),
+        });
         self
     }
 

--- a/src/v2/compile.rs
+++ b/src/v2/compile.rs
@@ -74,7 +74,19 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
         Method::Select => {
             // CTEs are emitted first so their binds (and pg `$N`) come first.
             write_ctes::<D>(ctx, &qb.ctes);
-            ctx.sql.push_str("SELECT ");
+            if !qb.distinct_on.is_empty() {
+                if !D::supports_distinct_on() {
+                    panic!("DISTINCT ON requires PostgreSQL");
+                }
+                ctx.sql.push_str("SELECT DISTINCT ON (");
+                let cols: Vec<String> = qb.distinct_on.iter().map(|c| ctx.esc(c)).collect();
+                ctx.sql.push_str(&cols.join(", "));
+                ctx.sql.push_str(") ");
+            } else if qb.distinct {
+                ctx.sql.push_str("SELECT DISTINCT ");
+            } else {
+                ctx.sql.push_str("SELECT ");
+            }
             if qb.select_cols.is_empty() {
                 ctx.sql.push('*');
             } else {
@@ -489,6 +501,29 @@ fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate) {
             ctx.placeholder::<D>(lo.clone());
             ctx.sql.push_str(" AND ");
             ctx.placeholder::<D>(hi.clone());
+        }
+        Predicate::ILike { col, val } => {
+            let col = ctx.esc(col);
+            if D::ilike_is_native() {
+                // Postgres: native `col ILIKE $n`.
+                ctx.sql.push_str(&col);
+                ctx.sql.push_str(" ILIKE ");
+                ctx.placeholder::<D>(val.clone());
+            } else {
+                // MySQL/SQLite: `LOWER(col) LIKE LOWER(?)`.
+                ctx.sql.push_str("LOWER(");
+                ctx.sql.push_str(&col);
+                ctx.sql.push_str(") LIKE LOWER(");
+                ctx.placeholder::<D>(val.clone());
+                ctx.sql.push(')');
+            }
+        }
+        Predicate::JsonContains { col, val } => {
+            // Postgres-oriented `@>` (jsonb contains); emitted verbatim.
+            let col = ctx.esc(col);
+            ctx.sql.push_str(&col);
+            ctx.sql.push_str(" @> ");
+            ctx.placeholder::<D>(val.clone());
         }
         Predicate::Raw { sql, binds } => {
             // Verbatim escape hatch: SQL is NOT escaped (see `where_raw` docs).

--- a/src/v2/dialect/mod.rs
+++ b/src/v2/dialect/mod.rs
@@ -44,6 +44,20 @@ pub trait Dialect: Sized + Send + Sync + 'static {
     fn upsert_style() -> UpsertStyle {
         UpsertStyle::OnConflict
     }
+
+    /// Whether this dialect supports `SELECT DISTINCT ON (cols)`. Defaults to
+    /// `false`; only Postgres overrides to `true`. Compiling a `distinct_on`
+    /// query against a dialect that returns `false` panics.
+    fn supports_distinct_on() -> bool {
+        false
+    }
+
+    /// Whether this dialect has a native case-insensitive `ILIKE` operator.
+    /// Defaults to `false`; only Postgres overrides to `true`. When `false`,
+    /// `where_ilike` is compiled as `LOWER(col) LIKE LOWER(?)`.
+    fn ilike_is_native() -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/v2/dialect/postgres.rs
+++ b/src/v2/dialect/postgres.rs
@@ -19,4 +19,12 @@ impl Dialect for Postgres {
     fn supports_returning() -> bool {
         true
     }
+
+    fn supports_distinct_on() -> bool {
+        true
+    }
+
+    fn ilike_is_native() -> bool {
+        true
+    }
 }

--- a/src/v2/where_.rs
+++ b/src/v2/where_.rs
@@ -61,6 +61,24 @@ pub enum Predicate {
         /// Upper bound.
         hi: Value,
     },
+    /// `col ILIKE val` — dialect-aware case-insensitive match.
+    ///
+    /// Postgres emits native `{col} ILIKE {ph}`; MySQL/SQLite emit
+    /// `LOWER({col}) LIKE LOWER({ph})`. Dispatched in `compile::write_pred`.
+    ILike {
+        /// Raw identifier; escaped in compile.rs.
+        col: String,
+        /// Bound value.
+        val: Value,
+    },
+    /// `col @> val` — JSONB containment (Postgres-oriented; `@>` emitted
+    /// verbatim for all dialects).
+    JsonContains {
+        /// Raw identifier; escaped in compile.rs.
+        col: String,
+        /// Bound value (JSON text or `Value::Json`).
+        val: Value,
+    },
     /// Raw SQL fragment with its own binds, emitted verbatim.
     Raw {
         /// Verbatim SQL.
@@ -162,6 +180,26 @@ impl<D: Dialect> WhereBuilder<D> {
     /// `col LIKE val`.
     pub fn where_like(self, col: &str, val: impl IntoBind) -> Self {
         self.binary(col, "LIKE", val)
+    }
+
+    /// `col ILIKE val` — dialect-aware case-insensitive match (see
+    /// [`QueryBuilder::where_ilike`](crate::v2::QueryBuilder::where_ilike)).
+    pub fn where_ilike(mut self, col: &str, val: impl IntoBind) -> Self {
+        self.preds.push(Predicate::ILike {
+            col: col.to_owned(),
+            val: val.into_bind(),
+        });
+        self
+    }
+
+    /// `col @> val` — JSONB containment (Postgres-oriented; see
+    /// [`QueryBuilder::where_jsonb_contains`](crate::v2::QueryBuilder::where_jsonb_contains)).
+    pub fn where_jsonb_contains(mut self, col: &str, val: impl IntoBind) -> Self {
+        self.preds.push(Predicate::JsonContains {
+            col: col.to_owned(),
+            val: val.into_bind(),
+        });
+        self
     }
 
     fn in_(mut self, col: &str, neg: bool, vals: impl IntoIterator<Item = impl IntoBind>) -> Self {

--- a/tests/v2_pg.rs
+++ b/tests/v2_pg.rs
@@ -1,0 +1,173 @@
+#![cfg(feature = "v2")]
+
+use chain_builder::v2::{MySql, Postgres, QueryBuilder, Sqlite, Value};
+
+// ---------------------------------------------------------------------------
+// DISTINCT / DISTINCT ON
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pg_distinct() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .distinct()
+        .select(["a"])
+        .to_sql();
+    assert_eq!(sql, r#"SELECT DISTINCT "a" FROM "t""#);
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn pg_distinct_on() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .distinct_on(["a", "b"])
+        .select(["a"])
+        .to_sql();
+    assert_eq!(sql, r#"SELECT DISTINCT ON ("a", "b") "a" FROM "t""#);
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn mysql_distinct() {
+    let (sql, _binds) = QueryBuilder::<MySql>::table("t")
+        .distinct()
+        .select(["a"])
+        .to_sql();
+    assert_eq!(sql, "SELECT DISTINCT `a` FROM `t`");
+}
+
+#[test]
+#[should_panic(expected = "DISTINCT ON requires PostgreSQL")]
+fn mysql_distinct_on_panics() {
+    let _ = QueryBuilder::<MySql>::table("t")
+        .distinct_on(["a"])
+        .select(["a"])
+        .to_sql();
+}
+
+// ---------------------------------------------------------------------------
+// ILIKE (dialect-aware)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pg_ilike() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .where_ilike("name", "%jo%")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "a" FROM "t" WHERE "name" ILIKE $1"#);
+    assert_eq!(binds, vec![Value::Text("%jo%".to_string())]);
+}
+
+#[test]
+fn mysql_ilike() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("t")
+        .select(["a"])
+        .where_ilike("name", "%jo%")
+        .to_sql();
+    assert_eq!(sql, "SELECT `a` FROM `t` WHERE LOWER(`name`) LIKE LOWER(?)");
+    assert_eq!(binds, vec![Value::Text("%jo%".to_string())]);
+}
+
+#[test]
+fn sqlite_ilike() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("t")
+        .select(["a"])
+        .where_ilike("name", "%jo%")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "a" FROM "t" WHERE LOWER("name") LIKE LOWER(?)"#);
+    assert_eq!(binds, vec![Value::Text("%jo%".to_string())]);
+}
+
+#[test]
+fn pg_ilike_placeholder_ordering() {
+    // A preceding WHERE so the ILIKE placeholder is $2.
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .where_eq("status", "active")
+        .where_ilike("name", "%jo%")
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "a" FROM "t" WHERE "status" = $1 AND "name" ILIKE $2"#
+    );
+    assert_eq!(
+        binds,
+        vec![
+            Value::Text("active".to_string()),
+            Value::Text("%jo%".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn pg_ilike_inside_or_where_group() {
+    // ILIKE within an or_where group: placeholder ordering continues.
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .where_eq("status", "active")
+        .or_where(|w| w.where_ilike("name", "%jo%").where_eq("age", 30i64))
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "a" FROM "t" WHERE "status" = $1 OR ("name" ILIKE $2 AND "age" = $3)"#
+    );
+    assert_eq!(
+        binds,
+        vec![
+            Value::Text("active".to_string()),
+            Value::Text("%jo%".to_string()),
+            Value::I64(30),
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// jsonb contains
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pg_jsonb_contains() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .where_jsonb_contains("meta", "{\"a\":1}")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "a" FROM "t" WHERE "meta" @> $1"#);
+    assert_eq!(binds, vec![Value::Text("{\"a\":1}".to_string())]);
+}
+
+#[test]
+fn pg_jsonb_contains_in_group() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .where_eq("status", "active")
+        .and_where(|w| w.where_jsonb_contains("meta", "{\"a\":1}"))
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "a" FROM "t" WHERE "status" = $1 AND ("meta" @> $2)"#
+    );
+    assert_eq!(
+        binds,
+        vec![
+            Value::Text("active".to_string()),
+            Value::Text("{\"a\":1}".to_string()),
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Regression: neither distinct nor ilike → byte-identical to M1.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn regression_plain_select_unchanged() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id", "name"])
+        .where_eq("status", "active")
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id", "name" FROM "users" WHERE "status" = $1"#
+    );
+    assert_eq!(binds, vec![Value::Text("active".to_string())]);
+}


### PR DESCRIPTION
## Summary
Milestone **M5** — Postgres parity extras (with dialect-aware fallbacks). Into `v2`.

- `distinct()` (all dialects) · `distinct_on(cols)` (pg `SELECT DISTINCT ON (…)`; panics on non-pg).
- `where_ilike(col, val)` — pg native `ILIKE`; MySQL/SQLite `LOWER(col) LIKE LOWER(?)`.
- `where_jsonb_contains(col, val)` — pg `col @> ?`.
- New `Dialect` capabilities `supports_distinct_on()` / `ilike_is_native()` (default false; Postgres overrides) — non-breaking.
- `ILike`/`JsonContains` are `Predicate` variants → correct placeholder ordering, usable inside `or_where` groups.

## Verification
- `tests/v2_pg.rs` **12 passing** (distinct/distinct_on/ilike per dialect, jsonb, group placeholder, distinct_on-panic, regression).
- M1–M4 **byte-identical** · 1.x **63** · pg 176 / mysql 173 / sqlite 173 · no `src/v2` clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)