### PR TITLE
✨ v2 M6: dynamic building (when) + pagination

### DIFF
--- a/src/v2/builder.rs
+++ b/src/v2/builder.rs
@@ -703,6 +703,84 @@ impl<D: Dialect> QueryBuilder<D> {
         self
     }
 
+    /// Conditionally apply `f` to the builder, keeping the chain intact.
+    ///
+    /// Returns `f(self)` when `cond` is true, otherwise `self` unchanged. This
+    /// lets you add clauses based on a runtime flag without breaking the
+    /// by-value chain.
+    ///
+    /// ```
+    /// # #[cfg(feature = "v2")] {
+    /// use chain_builder::v2::{Postgres, QueryBuilder};
+    /// let only_active = true;
+    /// let (sql, _) = QueryBuilder::<Postgres>::table("users")
+    ///     .select(["id"])
+    ///     .when(only_active, |q| q.where_eq("status", "active"))
+    ///     .to_sql();
+    /// assert_eq!(sql, r#"SELECT "id" FROM "users" WHERE "status" = $1"#);
+    /// # }
+    /// ```
+    pub fn when(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if cond {
+            f(self)
+        } else {
+            self
+        }
+    }
+
+    /// Apply `if_true` when `cond` holds, otherwise `if_false`, keeping the
+    /// chain intact.
+    ///
+    /// ```
+    /// # #[cfg(feature = "v2")] {
+    /// use chain_builder::v2::{Postgres, QueryBuilder};
+    /// let active = false;
+    /// let (sql, _) = QueryBuilder::<Postgres>::table("users")
+    ///     .select(["id"])
+    ///     .when_else(
+    ///         active,
+    ///         |q| q.where_eq("status", "active"),
+    ///         |q| q.where_eq("status", "inactive"),
+    ///     )
+    ///     .to_sql();
+    /// assert_eq!(sql, r#"SELECT "id" FROM "users" WHERE "status" = $1"#);
+    /// # }
+    /// ```
+    pub fn when_else(
+        self,
+        cond: bool,
+        if_true: impl FnOnce(Self) -> Self,
+        if_false: impl FnOnce(Self) -> Self,
+    ) -> Self {
+        if cond {
+            if_true(self)
+        } else {
+            if_false(self)
+        }
+    }
+
+    /// Apply `LIMIT`/`OFFSET` for a **1-based** page: row window
+    /// `[(page-1) * per_page, page * per_page)`.
+    ///
+    /// Equivalent to `self.limit(per_page).offset((page - 1).max(0) * per_page)`.
+    /// A `page < 1` is treated as page 1 (offset 0), so callers never get a
+    /// negative offset. SELECT-only, like [`Self::limit`] / [`Self::offset`].
+    ///
+    /// ```
+    /// # #[cfg(feature = "v2")] {
+    /// use chain_builder::v2::{Postgres, QueryBuilder, Value};
+    /// let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+    ///     .select(["id"])
+    ///     .paginate(2, 10)
+    ///     .to_sql();
+    /// assert_eq!(sql, r#"SELECT "id" FROM "users" LIMIT $1 OFFSET $2"#);
+    /// assert_eq!(binds, vec![Value::I64(10), Value::I64(10)]);
+    /// # }
+    /// ```
+    pub fn paginate(self, page: i64, per_page: i64) -> Self {
+        self.limit(per_page).offset((page - 1).max(0) * per_page)
+    }
+
     /// Compile to `(sql, binds)`.
     pub fn to_sql(&self) -> (String, Vec<Value>) {
         compile(self)

--- a/tests/v2_dynamic.rs
+++ b/tests/v2_dynamic.rs
@@ -1,0 +1,181 @@
+#![cfg(feature = "v2")]
+
+use chain_builder::v2::{MySql, Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn when_true_adds_predicate() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .when(true, |q| q.where_eq("a", 1i64))
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT "id" FROM "users" WHERE "a" = $1"#);
+    assert_eq!(binds, vec![Value::I64(1)]);
+}
+
+#[test]
+fn when_false_skips_predicate() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .when(false, |q| q.where_eq("a", 1i64))
+        .to_sql();
+
+    // No WHERE clause at all when the condition is false.
+    assert_eq!(sql, r#"SELECT "id" FROM "users""#);
+    assert!(!sql.contains("WHERE"));
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn when_true_and_false_differ() {
+    let (sql_true, _) = QueryBuilder::<Postgres>::table("users")
+        .when(true, |q| q.where_eq("a", 1i64))
+        .to_sql();
+    let (sql_false, _) = QueryBuilder::<Postgres>::table("users")
+        .when(false, |q| q.where_eq("a", 1i64))
+        .to_sql();
+    assert_ne!(sql_true, sql_false);
+}
+
+#[test]
+fn when_else_false_applies_false_branch() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .when_else(
+            false,
+            |q| q.where_eq("a", 1i64),
+            |q| q.where_eq("b", 2i64),
+        )
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT "id" FROM "users" WHERE "b" = $1"#);
+    assert_eq!(binds, vec![Value::I64(2)]);
+}
+
+#[test]
+fn when_else_true_applies_true_branch() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .when_else(
+            true,
+            |q| q.where_eq("a", 1i64),
+            |q| q.where_eq("b", 2i64),
+        )
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT "id" FROM "users" WHERE "a" = $1"#);
+    assert_eq!(binds, vec![Value::I64(1)]);
+}
+
+#[test]
+fn when_mid_chain_preserves_rest_of_builder() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .when(true, |q| q.where_eq("a", 1i64))
+        .order_by_desc("created")
+        .limit(5)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "status" = $1 AND "a" = $2 ORDER BY "created" DESC LIMIT $3"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("active".into()), Value::I64(1), Value::I64(5)]
+    );
+}
+
+#[test]
+fn when_false_mid_chain_preserves_rest_of_builder() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .when(false, |q| q.where_eq("a", 1i64))
+        .order_by_desc("created")
+        .limit(5)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "status" = $1 ORDER BY "created" DESC LIMIT $2"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("active".into()), Value::I64(5)]
+    );
+}
+
+#[test]
+fn paginate_page_2_pg() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .paginate(2, 10)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" LIMIT $1 OFFSET $2"#
+    );
+    assert_eq!(binds, vec![Value::I64(10), Value::I64(10)]);
+}
+
+#[test]
+fn paginate_page_1_offset_zero_pg() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .paginate(1, 10)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" LIMIT $1 OFFSET $2"#
+    );
+    assert_eq!(binds, vec![Value::I64(10), Value::I64(0)]);
+}
+
+#[test]
+fn paginate_page_zero_treated_as_page_one_pg() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .paginate(0, 10)
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" LIMIT $1 OFFSET $2"#
+    );
+    assert_eq!(binds, vec![Value::I64(10), Value::I64(0)]);
+}
+
+#[test]
+fn paginate_negative_page_treated_as_page_one_pg() {
+    let (_, binds) = QueryBuilder::<Postgres>::table("users")
+        .paginate(-5, 10)
+        .to_sql();
+
+    assert_eq!(binds, vec![Value::I64(10), Value::I64(0)]);
+}
+
+#[test]
+fn paginate_mysql_placeholder() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("users")
+        .select(["id"])
+        .paginate(2, 10)
+        .to_sql();
+
+    assert_eq!(sql, "SELECT `id` FROM `users` LIMIT ? OFFSET ?");
+    assert_eq!(binds, vec![Value::I64(10), Value::I64(10)]);
+}
+
+#[test]
+fn paginate_sqlite_placeholder() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("users")
+        .select(["id"])
+        .paginate(3, 5)
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT "id" FROM "users" LIMIT ? OFFSET ?"#);
+    assert_eq!(binds, vec![Value::I64(5), Value::I64(10)]);
+}


### PR DESCRIPTION
## Summary
Milestone **M6** — conditional building + pagination ergonomics. Into `v2`.
- `when(cond, |q| …)` / `when_else(cond, t, f)` — build clauses conditionally without breaking the fluent chain.
- `paginate(page, per_page)` — 1-based; `page<1` → offset 0; reuses `limit`/`offset`.

## Verification
`tests/v2_dynamic.rs` **13 passing** (when true/false, when_else branches, mid-chain preservation, paginate pg/mysql/sqlite + page edge cases) + 4 doctests. M1–M5 byte-identical · 1.x **63** · no `src/v2` clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)