### PR TITLE
✨ v2 M7: insert_many (multi-row) + group_by_raw/order_by_raw

### DIFF
--- a/src/v2/builder.rs
+++ b/src/v2/builder.rs
@@ -201,10 +201,19 @@ pub struct QueryBuilder<D: Dialect> {
     pub(crate) wheres: Vec<Predicate>,
     pub(crate) method: Method,
     pub(crate) set: Vec<(String, Value)>,
+    /// Multi-row `INSERT` rows (empty unless `insert_many` was used). Each row is
+    /// a `(column, value)` list; columns come from the first row's sorted keys.
+    pub(crate) insert_rows: Vec<Vec<(String, Value)>>,
     pub(crate) joins: Vec<Join>,
     pub(crate) groups: Vec<String>,
+    /// Raw `GROUP BY` fragment (verbatim) with its own binds, appended after any
+    /// structured `groups`.
+    pub(crate) group_by_raw: Option<(String, Vec<Value>)>,
     pub(crate) havings: Vec<Having>,
     pub(crate) orders: Vec<(String, Order)>,
+    /// Raw `ORDER BY` fragment (verbatim) with its own binds, appended after any
+    /// structured `orders`.
+    pub(crate) order_by_raw: Option<(String, Vec<Value>)>,
     pub(crate) limit: Option<i64>,
     pub(crate) offset: Option<i64>,
     pub(crate) ctes: Vec<Cte<D>>,
@@ -228,10 +237,13 @@ impl<D: Dialect> QueryBuilder<D> {
             wheres: Vec::new(),
             method: Method::Select,
             set: Vec::new(),
+            insert_rows: Vec::new(),
             joins: Vec::new(),
             groups: Vec::new(),
+            group_by_raw: None,
             havings: Vec::new(),
             orders: Vec::new(),
+            order_by_raw: None,
             limit: None,
             offset: None,
             ctes: Vec::new(),
@@ -454,6 +466,33 @@ impl<D: Dialect> QueryBuilder<D> {
         self
     }
 
+    /// Build a multi-row `INSERT` from an iterator of rows, each a sequence of
+    /// `(column, value)` pairs.
+    ///
+    /// The inserted column set is taken from the **first** row's keys (sorted, as
+    /// with [`Self::insert`]). For each subsequent row, a value is bound for every
+    /// column in that set; a key **missing** in a later row binds `Value::Null`
+    /// rather than panicking (DoS-safe, matching the 1.x hardening). Composes with
+    /// `on_conflict_*` and `returning`.
+    pub fn insert_many<K, V, R, Rows>(mut self, rows: Rows) -> Self
+    where
+        K: AsRef<str>,
+        V: IntoBind,
+        R: IntoIterator<Item = (K, V)>,
+        Rows: IntoIterator<Item = R>,
+    {
+        self.method = Method::Insert;
+        self.insert_rows = rows
+            .into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .map(|(k, v)| (k.as_ref().to_owned(), v.into_bind()))
+                    .collect()
+            })
+            .collect();
+        self
+    }
+
     /// Build an `UPDATE` from `(column, value)` pairs. WHERE still applies.
     pub fn update<K, V, I>(mut self, set: I) -> Self
     where
@@ -547,6 +586,46 @@ impl<D: Dialect> QueryBuilder<D> {
     {
         self.groups
             .extend(cols.into_iter().map(|c| c.as_ref().to_owned()));
+        self
+    }
+
+    /// Add a raw `GROUP BY` fragment with its own binds — the verbatim escape
+    /// hatch. SELECT-only.
+    ///
+    /// The fragment is appended after any structured [`Self::group_by`] columns
+    /// within the same `GROUP BY` clause (e.g. `GROUP BY "a", <raw>`); if no
+    /// structured columns are present it becomes the whole `GROUP BY <raw>`.
+    ///
+    /// # Warning: positional placeholder contract
+    ///
+    /// `sql` is emitted **verbatim** (it is NOT escaped or renumbered) and
+    /// `binds` are appended to the running bind list in order. For
+    /// **Postgres**, the caller MUST write `$N` numbers matching the actual
+    /// bind position — that is, `number of binds already accumulated + 1`, `+2`,
+    /// … For MySQL/SQLite use `?`. No renumbering is performed, so a wrong `$N`
+    /// produces a malformed query.
+    pub fn group_by_raw(mut self, sql: &str, binds: Vec<Value>) -> Self {
+        self.group_by_raw = Some((sql.to_owned(), binds));
+        self
+    }
+
+    /// Add a raw `ORDER BY` fragment with its own binds — the verbatim escape
+    /// hatch. SELECT-only.
+    ///
+    /// The fragment is appended after any structured [`Self::order_by`] terms
+    /// within the same `ORDER BY` clause (e.g. `ORDER BY "a" ASC, <raw>`); if no
+    /// structured terms are present it becomes the whole `ORDER BY <raw>`.
+    ///
+    /// # Warning: positional placeholder contract
+    ///
+    /// `sql` is emitted **verbatim** (it is NOT escaped or renumbered) and
+    /// `binds` are appended to the running bind list in order. For
+    /// **Postgres**, the caller MUST write `$N` numbers matching the actual
+    /// bind position — that is, `number of binds already accumulated + 1`, `+2`,
+    /// … For MySQL/SQLite use `?`. No renumbering is performed, so a wrong `$N`
+    /// produces a malformed query.
+    pub fn order_by_raw(mut self, sql: &str, binds: Vec<Value>) -> Self {
+        self.order_by_raw = Some((sql.to_owned(), binds));
         self
     }
 

--- a/src/v2/compile.rs
+++ b/src/v2/compile.rs
@@ -97,18 +97,30 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             ctx.sql.push_str(&table);
             write_joins::<D>(ctx, &qb.joins, qb.db.as_deref());
             write_wheres::<D>(ctx, &qb.wheres);
-            write_group_by(ctx, &qb.groups);
+            write_group_by(ctx, &qb.groups, qb.group_by_raw.as_ref());
             write_having::<D>(ctx, &qb.havings);
-            write_order_by(ctx, &qb.orders);
+            write_order_by(ctx, &qb.orders, qb.order_by_raw.as_ref());
             write_limit_offset::<D>(ctx, qb.limit, qb.offset);
             write_unions::<D>(ctx, &qb.unions);
         }
         Method::Insert => {
-            if qb.set.is_empty() {
+            if qb.set.is_empty() && qb.insert_rows.is_empty() {
                 panic!("insert() requires at least one column");
             }
-            let mut rows: Vec<&(String, Value)> = qb.set.iter().collect();
-            rows.sort_by(|a, b| a.0.cmp(&b.0));
+
+            // Single-row sorted pairs (preserves the M-prev path byte-for-byte,
+            // including duplicate keys). For multi-row, columns come from the
+            // FIRST row's sorted keys.
+            let mut single_rows: Vec<&(String, Value)> = qb.set.iter().collect();
+            single_rows.sort_by(|a, b| a.0.cmp(&b.0));
+            let sorted_cols: Vec<&str> = if !qb.insert_rows.is_empty() {
+                let mut cols: Vec<&str> =
+                    qb.insert_rows[0].iter().map(|(k, _)| k.as_str()).collect();
+                cols.sort_unstable();
+                cols
+            } else {
+                single_rows.iter().map(|(k, _)| k.as_str()).collect()
+            };
 
             // Decide the INSERT keyword up front: MySQL `DO NOTHING` becomes
             // `INSERT IGNORE INTO …` with no trailing conflict clause.
@@ -124,21 +136,47 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             }
             ctx.sql.push_str(&table);
             ctx.sql.push_str(" (");
-            let cols: Vec<String> = rows.iter().map(|(k, _)| ctx.esc(k)).collect();
+            let cols: Vec<String> = sorted_cols.iter().map(|k| ctx.esc(k)).collect();
             ctx.sql.push_str(&cols.join(", "));
-            ctx.sql.push_str(") VALUES (");
-            for (i, (_, v)) in rows.iter().enumerate() {
-                if i > 0 {
-                    ctx.sql.push_str(", ");
+            ctx.sql.push_str(") VALUES ");
+
+            if !qb.insert_rows.is_empty() {
+                // Multi-row: one `(…)` tuple per row. A key missing in a row binds
+                // `Value::Null` (ragged rows are NULL-padded, never a panic).
+                for (ri, row) in qb.insert_rows.iter().enumerate() {
+                    if ri > 0 {
+                        ctx.sql.push_str(", ");
+                    }
+                    ctx.sql.push('(');
+                    for (ci, col) in sorted_cols.iter().enumerate() {
+                        if ci > 0 {
+                            ctx.sql.push_str(", ");
+                        }
+                        let v = row
+                            .iter()
+                            .find(|(k, _)| k == col)
+                            .map(|(_, v)| v.clone())
+                            .unwrap_or(Value::Null);
+                        ctx.placeholder::<D>(v);
+                    }
+                    ctx.sql.push(')');
                 }
-                ctx.placeholder::<D>(v.clone());
+            } else {
+                // Single-row: byte-identical to the M-prev path (iterate the
+                // sorted (key, value) pairs directly, duplicates and all).
+                ctx.sql.push('(');
+                for (i, (_, v)) in single_rows.iter().enumerate() {
+                    if i > 0 {
+                        ctx.sql.push_str(", ");
+                    }
+                    ctx.placeholder::<D>(v.clone());
+                }
+                ctx.sql.push(')');
             }
-            ctx.sql.push(')');
 
             if !mysql_ignore {
                 if let Some(oc) = &qb.on_conflict {
-                    let inserted: Vec<&str> = rows.iter().map(|(k, _)| k.as_str()).collect();
-                    write_on_conflict::<D>(ctx, oc, &inserted);
+                    write_on_conflict::<D>(ctx, oc, &sorted_cols);
                 }
             }
             write_returning::<D>(ctx, &qb.returning);
@@ -246,14 +284,24 @@ fn write_returning<D: Dialect>(ctx: &mut Ctx, cols: &[String]) {
     ctx.sql.push_str(&parts.join(", "));
 }
 
-/// Render `GROUP BY a, b, …` (SELECT only). No-op when there are no columns.
-fn write_group_by(ctx: &mut Ctx, groups: &[String]) {
-    if groups.is_empty() {
+/// Render `GROUP BY a, b, …` (SELECT only). No-op when there are no columns and
+/// no raw fragment. A raw fragment is appended (comma-joined) after the
+/// structured columns; if only raw is present it becomes the whole clause.
+fn write_group_by(ctx: &mut Ctx, groups: &[String], raw: Option<&(String, Vec<Value>)>) {
+    if groups.is_empty() && raw.is_none() {
         return;
     }
     ctx.sql.push_str(" GROUP BY ");
     let cols: Vec<String> = groups.iter().map(|c| ctx.esc(c)).collect();
     ctx.sql.push_str(&cols.join(", "));
+    if let Some((sql, binds)) = raw {
+        if !groups.is_empty() {
+            ctx.sql.push_str(", ");
+        }
+        // Verbatim escape hatch (see `group_by_raw` docs).
+        ctx.sql.push_str(sql);
+        ctx.binds.extend(binds.iter().cloned());
+    }
 }
 
 /// Render each `JOIN` (SELECT only): ` {KIND} {esc table}[ ON cond AND …]`.
@@ -369,9 +417,11 @@ fn write_unions<D: Dialect>(ctx: &mut Ctx, unions: &[(bool, QueryBuilder<D>)]) {
     }
 }
 
-/// Render `ORDER BY a ASC, b DESC, …` (SELECT only). No-op when empty.
-fn write_order_by(ctx: &mut Ctx, orders: &[(String, Order)]) {
-    if orders.is_empty() {
+/// Render `ORDER BY a ASC, b DESC, …` (SELECT only). No-op when empty and no raw
+/// fragment. A raw fragment is appended (comma-joined) after the structured
+/// terms; if only raw is present it becomes the whole clause.
+fn write_order_by(ctx: &mut Ctx, orders: &[(String, Order)], raw: Option<&(String, Vec<Value>)>) {
+    if orders.is_empty() && raw.is_none() {
         return;
     }
     ctx.sql.push_str(" ORDER BY ");
@@ -386,6 +436,14 @@ fn write_order_by(ctx: &mut Ctx, orders: &[(String, Order)]) {
         })
         .collect();
     ctx.sql.push_str(&cols.join(", "));
+    if let Some((sql, binds)) = raw {
+        if !orders.is_empty() {
+            ctx.sql.push_str(", ");
+        }
+        // Verbatim escape hatch (see `order_by_raw` docs).
+        ctx.sql.push_str(sql);
+        ctx.binds.extend(binds.iter().cloned());
+    }
 }
 
 /// Render `LIMIT $n [OFFSET $m]` (SELECT only), binding both values.

--- a/tests/v2_gaps.rs
+++ b/tests/v2_gaps.rs
@@ -1,0 +1,173 @@
+#![cfg(feature = "v2")]
+
+use chain_builder::v2::{MySql, Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn pg_insert_many_basic() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("u")
+        .insert_many([
+            [("a", 1i64), ("b", 2i64)],
+            [("a", 3i64), ("b", 4i64)],
+        ])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "u" ("a", "b") VALUES ($1, $2), ($3, $4)"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::I64(1), Value::I64(2), Value::I64(3), Value::I64(4)]
+    );
+}
+
+#[test]
+fn pg_insert_many_ragged_binds_null() {
+    // Second row missing "b" → that slot binds Null.
+    let (sql, binds) = QueryBuilder::<Postgres>::table("u")
+        .insert_many([
+            vec![("a", 1i64), ("b", 2i64)],
+            vec![("a", 3i64)],
+        ])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "u" ("a", "b") VALUES ($1, $2), ($3, $4)"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::I64(1), Value::I64(2), Value::I64(3), Value::Null]
+    );
+}
+
+#[test]
+fn mysql_insert_many() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("u")
+        .insert_many([
+            [("a", 1i64), ("b", 2i64)],
+            [("a", 3i64), ("b", 4i64)],
+        ])
+        .to_sql();
+    assert_eq!(sql, "INSERT INTO `u` (`a`, `b`) VALUES (?, ?), (?, ?)");
+    assert_eq!(
+        binds,
+        vec![Value::I64(1), Value::I64(2), Value::I64(3), Value::I64(4)]
+    );
+}
+
+#[test]
+fn sqlite_insert_many() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("u")
+        .insert_many([
+            [("a", 1i64), ("b", 2i64)],
+            [("a", 3i64), ("b", 4i64)],
+        ])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "u" ("a", "b") VALUES (?, ?), (?, ?)"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::I64(1), Value::I64(2), Value::I64(3), Value::I64(4)]
+    );
+}
+
+#[test]
+fn pg_insert_many_with_on_conflict_and_returning() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("u")
+        .insert_many([
+            [("a", 1i64), ("b", 2i64)],
+            [("a", 3i64), ("b", 4i64)],
+        ])
+        .on_conflict_do_nothing(["a"])
+        .returning(["a"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"INSERT INTO "u" ("a", "b") VALUES ($1, $2), ($3, $4) ON CONFLICT ("a") DO NOTHING RETURNING "a""#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::I64(1), Value::I64(2), Value::I64(3), Value::I64(4)]
+    );
+}
+
+#[test]
+fn pg_group_by_raw_verbatim() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .group_by_raw("date_trunc('day', created_at)", vec![])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "a" FROM "t" GROUP BY date_trunc('day', created_at)"#
+    );
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn pg_order_by_raw_verbatim_with_bind() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .order_by_raw("CASE WHEN a = $1 THEN 0 ELSE 1 END", vec![Value::I64(5)])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "a" FROM "t" ORDER BY CASE WHEN a = $1 THEN 0 ELSE 1 END"#
+    );
+    assert_eq!(binds, vec![Value::I64(5)]);
+}
+
+#[test]
+fn sqlite_group_order_by_raw() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("t")
+        .select(["a"])
+        .group_by_raw("a, b", vec![])
+        .order_by_raw("a DESC", vec![])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "a" FROM "t" GROUP BY a, b ORDER BY a DESC"#
+    );
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn pg_group_order_by_raw_appends_to_structured() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .group_by(["a"])
+        .group_by_raw("LOWER(b)", vec![])
+        .order_by_asc("a")
+        .order_by_raw("LOWER(b)", vec![])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "a" FROM "t" GROUP BY "a", LOWER(b) ORDER BY "a" ASC, LOWER(b)"#
+    );
+}
+
+// --- Regression: single-row insert and structured group/order unchanged ---
+
+#[test]
+fn pg_single_row_insert_unchanged() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("u")
+        .insert([("a", 1i64), ("b", 2i64)])
+        .to_sql();
+    assert_eq!(sql, r#"INSERT INTO "u" ("a", "b") VALUES ($1, $2)"#);
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(2)]);
+}
+
+#[test]
+fn pg_structured_group_order_unchanged() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("t")
+        .select(["a"])
+        .group_by(["a", "b"])
+        .order_by_asc("a")
+        .order_by_desc("b")
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "a" FROM "t" GROUP BY "a", "b" ORDER BY "a" ASC, "b" DESC"#
+    );
+}


### PR DESCRIPTION
## Summary
Milestone **M7** — fills the remaining query-builder gaps. Into `v2`.
- `insert_many(rows)` — multi-row INSERT; columns from the first row; missing keys in later rows bind `NULL` (DoS-safe, matches 1.x hardening); composes with `on_conflict`/`returning`. Single-row `insert()` byte-identical.
- `group_by_raw(sql, binds)` / `order_by_raw(sql, binds)` — verbatim (append to structured columns; pg `$N` caller-responsibility, same Warning as `where_raw`).

## Verification
`tests/v2_gaps.rs` **11 passing** (multi-row pg/mysql/sqlite, ragged→NULL, composes with on_conflict+returning, raw group/order, single-row regression). M1–M6 **byte-identical** · 1.x **63** · pg 203 / mysql 200 / sqlite 200 · no `src/v2` clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)