### PR TITLE
✨ M8: subqueries + where_column + select_raw (1.x parity)

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -82,6 +82,7 @@ pub enum Having {
 }
 
 /// A common table expression (`WITH` / `WITH RECURSIVE`).
+#[derive(Debug, Clone, PartialEq)]
 pub struct Cte<D: Dialect> {
     /// Raw CTE name (escaped at compile time).
     pub name: String,
@@ -188,17 +189,24 @@ pub enum Method {
 }
 
 /// Typed, dialect-aware SQL query builder.
+#[derive(Debug, Clone, PartialEq)]
 pub struct QueryBuilder<D: Dialect> {
     pub(crate) table: String,
     /// Optional database/schema qualifier (multi-tenant: one connection, many DBs).
     /// When set, prefixes the main table and join tables: `"db"."table"`.
     pub(crate) db: Option<String>,
     pub(crate) select_cols: Vec<String>,
+    /// Raw `SELECT` expressions (verbatim, NOT escaped) with their own binds,
+    /// appended after `select_cols`. Backs `select_raw`.
+    pub(crate) select_raw: Vec<(String, Vec<Value>)>,
+    /// Subquery `SELECT` columns: `(alias, sub)` → `(<sub>) AS {esc alias}`,
+    /// appended after `select_cols` / `select_raw`. Backs `select_subquery`.
+    pub(crate) select_subqueries: Vec<(String, Box<QueryBuilder<D>>)>,
     /// `SELECT DISTINCT` flag (raw; off by default for M1 byte-identity).
     pub(crate) distinct: bool,
     /// `SELECT DISTINCT ON (cols)` columns (raw; Postgres-only).
     pub(crate) distinct_on: Vec<String>,
-    pub(crate) wheres: Vec<Predicate>,
+    pub(crate) wheres: Vec<Predicate<D>>,
     pub(crate) method: Method,
     pub(crate) set: Vec<(String, Value)>,
     /// Multi-row `INSERT` rows (empty unless `insert_many` was used). Each row is
@@ -232,6 +240,8 @@ impl<D: Dialect> QueryBuilder<D> {
             table: name.to_owned(),
             db: None,
             select_cols: Vec::new(),
+            select_raw: Vec::new(),
+            select_subqueries: Vec::new(),
             distinct: false,
             distinct_on: Vec::new(),
             wheres: Vec::new(),
@@ -271,6 +281,36 @@ impl<D: Dialect> QueryBuilder<D> {
         S: AsRef<str>,
     {
         self.select_cols = cols.into_iter().map(|c| c.as_ref().to_owned()).collect();
+        self
+    }
+
+    /// Add a raw `SELECT` expression (verbatim, NOT escaped) with optional binds
+    /// — the escape hatch for aggregates/functions like `COUNT(*)`.
+    ///
+    /// Appended to the column list after any [`Self::select`] columns. Multiple
+    /// calls accumulate.
+    ///
+    /// # Warning: positional placeholder contract
+    ///
+    /// `sql` is emitted **verbatim** (it is NOT escaped or renumbered) and any
+    /// `binds` are appended to the running bind list in order. For **Postgres**,
+    /// the caller MUST write `$N` numbers matching the actual bind position. For
+    /// MySQL/SQLite use `?`.
+    pub fn select_raw(mut self, sql: &str, binds: Option<Vec<Value>>) -> Self {
+        self.select_raw
+            .push((sql.to_owned(), binds.unwrap_or_default()));
+        self
+    }
+
+    /// Add a subquery `SELECT` column: emits `(<sub>) AS {alias}` after the
+    /// regular columns and any [`Self::select_raw`] expressions.
+    ///
+    /// The subquery is compiled with placeholder continuity (its binds appear in
+    /// `$N` order at the point it is emitted — before the `WHERE` clause, since
+    /// the SELECT list is rendered first). SELECT-only.
+    pub fn select_subquery(mut self, alias: &str, sub: QueryBuilder<D>) -> Self {
+        self.select_subqueries
+            .push((alias.to_owned(), Box::new(sub)));
         self
     }
 
@@ -427,6 +467,58 @@ impl<D: Dialect> QueryBuilder<D> {
         self.wheres.push(Predicate::Raw {
             sql: sql.to_owned(),
             binds,
+        });
+        self
+    }
+
+    /// `lhs op rhs` — compare two column identifiers (both escaped at compile
+    /// time), no bind. e.g. `where_column("orders.user_id", "=", "users.id")`.
+    pub fn where_column(mut self, lhs: &str, op: &'static str, rhs: &str) -> Self {
+        self.wheres.push(Predicate::Column {
+            lhs: lhs.to_owned(),
+            op,
+            rhs: rhs.to_owned(),
+        });
+        self
+    }
+
+    /// `EXISTS (subquery)` — takes an already-built sub-builder by value
+    /// (mirrors [`Self::union`] / [`Self::with`]). The sub-query is compiled
+    /// with placeholder continuity.
+    pub fn where_exists(mut self, sub: QueryBuilder<D>) -> Self {
+        self.wheres.push(Predicate::Exists {
+            neg: false,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `NOT EXISTS (subquery)`. See [`Self::where_exists`].
+    pub fn where_not_exists(mut self, sub: QueryBuilder<D>) -> Self {
+        self.wheres.push(Predicate::Exists {
+            neg: true,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `col IN (subquery)` — takes an already-built sub-builder by value. The
+    /// sub-query is compiled with placeholder continuity.
+    pub fn where_in_subquery(mut self, col: &str, sub: QueryBuilder<D>) -> Self {
+        self.wheres.push(Predicate::InSubquery {
+            col: col.to_owned(),
+            neg: false,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `col NOT IN (subquery)`. See [`Self::where_in_subquery`].
+    pub fn where_not_in_subquery(mut self, col: &str, sub: QueryBuilder<D>) -> Self {
+        self.wheres.push(Predicate::InSubquery {
+            col: col.to_owned(),
+            neg: true,
+            sub: Box::new(sub),
         });
         self
     }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -87,12 +87,7 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             } else {
                 ctx.sql.push_str("SELECT ");
             }
-            if qb.select_cols.is_empty() {
-                ctx.sql.push('*');
-            } else {
-                let cols: Vec<String> = qb.select_cols.iter().map(|c| ctx.esc(c)).collect();
-                ctx.sql.push_str(&cols.join(", "));
-            }
+            write_select_list::<D>(ctx, qb);
             ctx.sql.push_str(" FROM ");
             ctx.sql.push_str(&table);
             write_joins::<D>(ctx, &qb.joins, qb.db.as_deref());
@@ -304,6 +299,48 @@ fn write_group_by(ctx: &mut Ctx, groups: &[String], raw: Option<&(String, Vec<Va
     }
 }
 
+/// Render the SELECT column list: escaped `select_cols`, then verbatim
+/// `select_raw` expressions, then `(<subquery>) AS {alias}` columns — in that
+/// order. An empty list (no cols, no raw, no subqueries) yields `*`.
+///
+/// Written directly into `ctx` (not pre-joined) so subquery binds continue the
+/// placeholder counter in emission order.
+fn write_select_list<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
+    if qb.select_cols.is_empty() && qb.select_raw.is_empty() && qb.select_subqueries.is_empty() {
+        ctx.sql.push('*');
+        return;
+    }
+    let mut wrote_any = false;
+    for c in &qb.select_cols {
+        if wrote_any {
+            ctx.sql.push_str(", ");
+        }
+        let e = ctx.esc(c);
+        ctx.sql.push_str(&e);
+        wrote_any = true;
+    }
+    for (sql, binds) in &qb.select_raw {
+        if wrote_any {
+            ctx.sql.push_str(", ");
+        }
+        // Verbatim escape hatch (see `select_raw` docs).
+        ctx.sql.push_str(sql);
+        ctx.binds.extend(binds.iter().cloned());
+        wrote_any = true;
+    }
+    for (alias, sub) in &qb.select_subqueries {
+        if wrote_any {
+            ctx.sql.push_str(", ");
+        }
+        ctx.sql.push('(');
+        compile_into::<D>(ctx, sub);
+        ctx.sql.push_str(") AS ");
+        let a = ctx.esc(alias);
+        ctx.sql.push_str(&a);
+        wrote_any = true;
+    }
+}
+
 /// Render each `JOIN` (SELECT only): ` {KIND} {esc table}[ ON cond AND …]`.
 /// `CROSS JOIN` emits no `ON`. Placeholders from `OnVal`/`OnRaw` continue the
 /// running counter.
@@ -467,11 +504,11 @@ fn write_limit_offset<D: Dialect>(ctx: &mut Ctx, limit: Option<i64>, offset: Opt
 /// A predicate produces no SQL if it is an empty group (F4): an empty group
 /// would emit invalid `()`, so it is skipped entirely (and must not leave a
 /// dangling `AND`/`OR` separator behind it).
-fn is_omitted(p: &Predicate) -> bool {
+fn is_omitted<D: Dialect>(p: &Predicate<D>) -> bool {
     matches!(p, Predicate::Group { preds, .. } if preds.is_empty())
 }
 
-fn write_wheres<D: Dialect>(ctx: &mut Ctx, wheres: &[Predicate]) {
+fn write_wheres<D: Dialect>(ctx: &mut Ctx, wheres: &[Predicate<D>]) {
     // Skip empty groups so they neither emit `()` nor force a `WHERE`.
     if wheres.iter().all(is_omitted) {
         return;
@@ -484,7 +521,7 @@ fn write_wheres<D: Dialect>(ctx: &mut Ctx, wheres: &[Predicate]) {
 /// but a [`Predicate::Group`] attaches to the preceding clause using its own
 /// outer conjunction (so `or_where` emits `... OR (...)`). Empty groups are
 /// omitted and never contribute a separator.
-fn write_clause_list<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate]) {
+fn write_clause_list<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate<D>]) {
     let mut wrote_any = false;
     for p in preds.iter() {
         if is_omitted(p) {
@@ -506,7 +543,7 @@ fn write_clause_list<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate]) {
 }
 
 /// Render a list of predicates joined by `conj` (used inside groups).
-fn write_preds<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate], conj: Conj) {
+fn write_preds<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate<D>], conj: Conj) {
     let sep = match conj {
         Conj::And => " AND ",
         Conj::Or => " OR ",
@@ -519,7 +556,7 @@ fn write_preds<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate], conj: Conj) {
     }
 }
 
-fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate) {
+fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate<D>) {
     match pred {
         Predicate::Binary { col, op, val } => {
             let col = ctx.esc(col);
@@ -603,6 +640,28 @@ fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate) {
             // emit invalid `()`.
             ctx.sql.push('(');
             write_preds::<D>(ctx, preds, Conj::And);
+            ctx.sql.push(')');
+        }
+        Predicate::Column { lhs, op, rhs } => {
+            let l = ctx.esc(lhs);
+            let r = ctx.esc(rhs);
+            ctx.sql.push_str(&l);
+            ctx.sql.push(' ');
+            ctx.sql.push_str(op);
+            ctx.sql.push(' ');
+            ctx.sql.push_str(&r);
+        }
+        Predicate::Exists { neg, sub } => {
+            ctx.sql
+                .push_str(if *neg { "NOT EXISTS (" } else { "EXISTS (" });
+            compile_into::<D>(ctx, sub);
+            ctx.sql.push(')');
+        }
+        Predicate::InSubquery { col, neg, sub } => {
+            let col = ctx.esc(col);
+            ctx.sql.push_str(&col);
+            ctx.sql.push_str(if *neg { " NOT IN (" } else { " IN (" });
+            compile_into::<D>(ctx, sub);
             ctx.sql.push(')');
         }
     }

--- a/src/where_.rs
+++ b/src/where_.rs
@@ -7,6 +7,7 @@
 
 use core::marker::PhantomData;
 
+use crate::builder::QueryBuilder;
 use crate::dialect::Dialect;
 use crate::value::{IntoBind, Value};
 
@@ -25,8 +26,12 @@ pub enum Conj {
 }
 
 /// A single WHERE-clause predicate.
+///
+/// Generic over the [`Dialect`] marker `D` because subquery-bearing variants
+/// ([`Predicate::Exists`] / [`Predicate::InSubquery`]) embed a
+/// [`QueryBuilder<D>`]; the recursion is broken with a `Box`.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Predicate {
+pub enum Predicate<D: Dialect> {
     /// `col op value`, e.g. `"age" > $1`.
     Binary {
         /// Raw identifier; escaped in compile.rs.
@@ -95,7 +100,33 @@ pub enum Predicate {
         /// How this group attaches to the preceding clause (outer separator).
         outer_conj: Conj,
         /// Inner predicates (always `AND`-joined in M1).
-        preds: Vec<Predicate>,
+        preds: Vec<Predicate<D>>,
+    },
+    /// `lhs op rhs` — both sides are column identifiers (escaped at compile
+    /// time), no bind. Backs `where_column`.
+    Column {
+        /// Raw left identifier; escaped in compile.rs.
+        lhs: String,
+        /// SQL operator token (`=`, `!=`, …).
+        op: &'static str,
+        /// Raw right identifier; escaped in compile.rs.
+        rhs: String,
+    },
+    /// `[NOT ]EXISTS (subquery)`.
+    Exists {
+        /// Whether this is `NOT EXISTS`.
+        neg: bool,
+        /// The embedded sub-query, compiled with placeholder continuity.
+        sub: Box<QueryBuilder<D>>,
+    },
+    /// `col [NOT ]IN (subquery)`.
+    InSubquery {
+        /// Raw identifier; escaped in compile.rs.
+        col: String,
+        /// Whether this is `NOT IN`.
+        neg: bool,
+        /// The embedded sub-query, compiled with placeholder continuity.
+        sub: Box<QueryBuilder<D>>,
     },
 }
 
@@ -114,7 +145,7 @@ pub enum Predicate {
 /// `OR` available is the *outer* attachment chosen by `or_where` (which emits
 /// `... OR (...)`). Nested groups and inner-`OR` are a documented M1 limitation.
 pub struct WhereBuilder<D: Dialect> {
-    preds: Vec<Predicate>,
+    preds: Vec<Predicate<D>>,
     _marker: PhantomData<D>,
 }
 
@@ -134,7 +165,7 @@ impl<D: Dialect> WhereBuilder<D> {
     }
 
     /// Consume the accumulator and return the collected predicates.
-    pub(crate) fn into_preds(self) -> Vec<Predicate> {
+    pub(crate) fn into_preds(self) -> Vec<Predicate<D>> {
         self.preds
     }
 
@@ -263,6 +294,18 @@ impl<D: Dialect> WhereBuilder<D> {
         self.preds.push(Predicate::Raw {
             sql: sql.to_owned(),
             binds,
+        });
+        self
+    }
+
+    /// `lhs op rhs` — compare two column identifiers (both escaped at compile
+    /// time), no bind. See
+    /// [`QueryBuilder::where_column`](crate::QueryBuilder::where_column).
+    pub fn where_column(mut self, lhs: &str, op: &'static str, rhs: &str) -> Self {
+        self.preds.push(Predicate::Column {
+            lhs: lhs.to_owned(),
+            op,
+            rhs: rhs.to_owned(),
         });
         self
     }

--- a/tests/subquery.rs
+++ b/tests/subquery.rs
@@ -1,0 +1,179 @@
+//! M8: subqueries + `where_column`.
+
+use chain_builder::{MySql, Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn pg_where_exists_placeholder_continuity() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("active", true)
+        .where_exists(
+            QueryBuilder::<Postgres>::table("orders")
+                .select(["1"])
+                .where_column("orders.user_id", "=", "users.id")
+                .where_gt("total", 100i64),
+        )
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "active" = $1 AND EXISTS (SELECT "1" FROM "orders" WHERE "orders"."user_id" = "users"."id" AND "total" > $2)"#
+    );
+    assert_eq!(binds, vec![Value::Bool(true), Value::I64(100)]);
+}
+
+#[test]
+fn pg_where_not_exists() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_not_exists(
+            QueryBuilder::<Postgres>::table("orders")
+                .select(["1"])
+                .where_column("orders.user_id", "=", "users.id"),
+        )
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE NOT EXISTS (SELECT "1" FROM "orders" WHERE "orders"."user_id" = "users"."id")"#
+    );
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn pg_where_in_subquery() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_in_subquery(
+            "id",
+            QueryBuilder::<Postgres>::table("ban")
+                .select(["user_id"])
+                .where_eq("k", 7i64),
+        )
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "id" IN (SELECT "user_id" FROM "ban" WHERE "k" = $1)"#
+    );
+    assert_eq!(binds, vec![Value::I64(7)]);
+}
+
+#[test]
+fn pg_where_not_in_subquery() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_not_in_subquery(
+            "id",
+            QueryBuilder::<Postgres>::table("ban")
+                .select(["user_id"])
+                .where_eq("k", 7i64),
+        )
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "id" NOT IN (SELECT "user_id" FROM "ban" WHERE "k" = $1)"#
+    );
+    assert_eq!(binds, vec![Value::I64(7)]);
+}
+
+#[test]
+fn pg_where_column_standalone() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["x"])
+        .where_column("a.x", "=", "b.y")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "x" FROM "t" WHERE "a"."x" = "b"."y""#);
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn pg_select_subquery() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .select_subquery(
+            "cnt",
+            QueryBuilder::<Postgres>::table("orders")
+                .select_raw("COUNT(*)", None)
+                .where_column("orders.uid", "=", "users.id"),
+        )
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id", (SELECT COUNT(*) FROM "orders" WHERE "orders"."uid" = "users"."id") AS "cnt" FROM "users""#
+    );
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn pg_select_subquery_bind_before_where_bind() {
+    // The select-list subquery carries a bind ($1); the outer WHERE carries
+    // another ($2). SELECT is emitted first, so the subquery bind must be $1.
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .select_subquery(
+            "cnt",
+            QueryBuilder::<Postgres>::table("orders")
+                .select_raw("COUNT(*)", None)
+                .where_eq("status", 1i64),
+        )
+        .where_eq("active", true)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id", (SELECT COUNT(*) FROM "orders" WHERE "status" = $1) AS "cnt" FROM "users" WHERE "active" = $2"#
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::Bool(true)]);
+}
+
+#[test]
+fn mysql_where_exists() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("users")
+        .select(["id"])
+        .where_exists(
+            QueryBuilder::<MySql>::table("orders")
+                .select(["1"])
+                .where_column("orders.user_id", "=", "users.id")
+                .where_gt("total", 100i64),
+        )
+        .to_sql();
+    assert_eq!(
+        sql,
+        "SELECT `id` FROM `users` WHERE EXISTS (SELECT `1` FROM `orders` WHERE `orders`.`user_id` = `users`.`id` AND `total` > ?)"
+    );
+    assert_eq!(binds, vec![Value::I64(100)]);
+}
+
+#[test]
+fn sqlite_where_in_subquery() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("users")
+        .select(["id"])
+        .where_in_subquery(
+            "id",
+            QueryBuilder::<Sqlite>::table("ban")
+                .select(["user_id"])
+                .where_eq("k", 7i64),
+        )
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "id" IN (SELECT "user_id" FROM "ban" WHERE "k" = ?)"#
+    );
+    assert_eq!(binds, vec![Value::I64(7)]);
+}
+
+#[test]
+fn regression_plain_builder_unchanged() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id", "name"])
+        .where_eq("active", true)
+        .where_gt("age", 18i64)
+        .order_by_asc("name")
+        .limit(10)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id", "name" FROM "users" WHERE "active" = $1 AND "age" > $2 ORDER BY "name" ASC LIMIT $3"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Bool(true), Value::I64(18), Value::I64(10)]
+    );
+}


### PR DESCRIPTION
## Summary
Closes the regression vs 1.x: **subqueries** + `where_column` + `select_raw` (the last was silently missing in v2). Into `v2`.

- `where_column(lhs, op, rhs)` — column-to-column.
- `where_exists`/`where_not_exists(sub)`, `where_in_subquery`/`where_not_in_subquery(col, sub)` — take a built `QueryBuilder<D>` (matches `union`/`with` convention).
- `select_subquery(alias, sub)` — `(SELECT …) AS alias`.
- `select_raw(sql, binds)` — verbatim select expression (was absent).
- `Predicate` is now `Predicate<D>` (holds `Box<QueryBuilder<D>>`); `QueryBuilder`/`Cte` gain `Debug/Clone/PartialEq`.

## Placeholder continuity (verified)
pg `$1` outer → `$2` inner across EXISTS/IN(subquery); SELECT-list subquery bind precedes WHERE bind.

## Verification
`tests/subquery.rs` **10** · M1–M7 prior **110 byte-identical** · default **148** · all-3 **154** · clippy `-D warnings` clean · fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)