### PR TITLE
✨ M9: feature-gated uuid/chrono bind types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +72,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,8 +120,21 @@ dependencies = [
 name = "chain-builder"
 version = "2.0.0"
 dependencies = [
+ "chrono",
  "serde_json",
  "sqlx",
+ "uuid",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -123,6 +151,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -482,6 +516,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +665,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -800,6 +869,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +1014,7 @@ dependencies = [
  "base64",
  "bytes",
  "cfg-if",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -960,6 +1036,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1009,6 +1086,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest 0.11.3",
  "dotenvy",
@@ -1024,6 +1102,7 @@ dependencies = [
  "sqlx-core",
  "thiserror",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1036,6 +1115,7 @@ dependencies = [
  "base64",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -1058,6 +1138,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -1068,6 +1149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "form_urlencoded",
  "futures-channel",
@@ -1083,6 +1165,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1259,6 +1342,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1379,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1329,10 +1467,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ repository = "https://github.com/AssetsArt/chain-builder.git"
 [dependencies]
 sqlx = { version = "0.9" }
 serde_json = { version = "1", optional = true }
+uuid = { version = "1", optional = true }
+chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 sqlx = { version = "0.9", features = ["mysql", "sqlite", "postgres"] }
@@ -23,3 +25,5 @@ sqlx_mysql = ["sqlx/mysql"]
 sqlx_sqlite = ["sqlx/sqlite"]
 sqlx_postgres = ["sqlx/postgres"]
 json = ["dep:serde_json"]
+uuid = ["dep:uuid", "sqlx/uuid"]
+chrono = ["dep:chrono", "sqlx/chrono"]

--- a/src/sqlx_bind.rs
+++ b/src/sqlx_bind.rs
@@ -86,6 +86,26 @@ impl SqlxDialect for Postgres {
                     // Match 1.x: store JSON as text.
                     let _ = arguments.add(serde_json::to_string(j).unwrap_or_default());
                 }
+                #[cfg(feature = "uuid")]
+                Value::Uuid(u) => {
+                    let _ = arguments.add(*u);
+                }
+                #[cfg(feature = "chrono")]
+                Value::DateTimeUtc(dt) => {
+                    let _ = arguments.add(*dt);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveDateTime(dt) => {
+                    let _ = arguments.add(*dt);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveDate(d) => {
+                    let _ = arguments.add(*d);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveTime(t) => {
+                    let _ = arguments.add(*t);
+                }
             }
         }
         arguments
@@ -124,6 +144,26 @@ impl SqlxDialect for MySql {
                 Value::Json(j) => {
                     // Match 1.x: store JSON as text.
                     let _ = arguments.add(serde_json::to_string(j).unwrap_or_default());
+                }
+                #[cfg(feature = "uuid")]
+                Value::Uuid(u) => {
+                    let _ = arguments.add(*u);
+                }
+                #[cfg(feature = "chrono")]
+                Value::DateTimeUtc(dt) => {
+                    let _ = arguments.add(*dt);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveDateTime(dt) => {
+                    let _ = arguments.add(*dt);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveDate(d) => {
+                    let _ = arguments.add(*d);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveTime(t) => {
+                    let _ = arguments.add(*t);
                 }
             }
         }
@@ -165,6 +205,26 @@ impl SqlxDialect for Sqlite {
                 Value::Json(j) => {
                     // Match 1.x: store JSON as text.
                     let _ = arguments.add(serde_json::to_string(j).unwrap_or_default());
+                }
+                #[cfg(feature = "uuid")]
+                Value::Uuid(u) => {
+                    let _ = arguments.add(*u);
+                }
+                #[cfg(feature = "chrono")]
+                Value::DateTimeUtc(dt) => {
+                    let _ = arguments.add(*dt);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveDateTime(dt) => {
+                    let _ = arguments.add(*dt);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveDate(d) => {
+                    let _ = arguments.add(*d);
+                }
+                #[cfg(feature = "chrono")]
+                Value::NaiveTime(t) => {
+                    let _ = arguments.add(*t);
                 }
             }
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -26,6 +26,21 @@ pub enum Value {
     /// JSON value (requires the `json` feature).
     #[cfg(feature = "json")]
     Json(serde_json::Value),
+    /// UUID (requires the `uuid` feature).
+    #[cfg(feature = "uuid")]
+    Uuid(uuid::Uuid),
+    /// Timezone-aware timestamp in UTC (requires the `chrono` feature).
+    #[cfg(feature = "chrono")]
+    DateTimeUtc(chrono::DateTime<chrono::Utc>),
+    /// Naive (timezone-less) date and time (requires the `chrono` feature).
+    #[cfg(feature = "chrono")]
+    NaiveDateTime(chrono::NaiveDateTime),
+    /// Naive date (requires the `chrono` feature).
+    #[cfg(feature = "chrono")]
+    NaiveDate(chrono::NaiveDate),
+    /// Naive time of day (requires the `chrono` feature).
+    #[cfg(feature = "chrono")]
+    NaiveTime(chrono::NaiveTime),
 }
 
 /// Conversion of a Rust value into a bound [`Value`].
@@ -129,6 +144,41 @@ impl<T: IntoBind> IntoBind for Option<T> {
 impl IntoBind for serde_json::Value {
     fn into_bind(self) -> Value {
         Value::Json(self)
+    }
+}
+
+#[cfg(feature = "uuid")]
+impl IntoBind for uuid::Uuid {
+    fn into_bind(self) -> Value {
+        Value::Uuid(self)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl IntoBind for chrono::DateTime<chrono::Utc> {
+    fn into_bind(self) -> Value {
+        Value::DateTimeUtc(self)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl IntoBind for chrono::NaiveDateTime {
+    fn into_bind(self) -> Value {
+        Value::NaiveDateTime(self)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl IntoBind for chrono::NaiveDate {
+    fn into_bind(self) -> Value {
+        Value::NaiveDate(self)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl IntoBind for chrono::NaiveTime {
+    fn into_bind(self) -> Value {
+        Value::NaiveTime(self)
     }
 }
 

--- a/tests/typebinds.rs
+++ b/tests/typebinds.rs
@@ -1,0 +1,108 @@
+//! M9: feature-gated `uuid` / `chrono` bind types.
+//!
+//! Each module is gated by its feature so the default test build stays green and
+//! byte-identical. Tests assert both that `IntoBind` produces the right `Value`
+//! variant (no DB needed) and that the value flows through `to_sql` as a bind.
+
+#[cfg(feature = "uuid")]
+mod uuid_tests {
+    use chain_builder::{IntoBind, Postgres, QueryBuilder, Value};
+
+    #[test]
+    fn uuid_into_bind_is_uuid_variant() {
+        let id = uuid::Uuid::nil();
+        assert_eq!(id.into_bind(), Value::Uuid(id));
+    }
+
+    #[test]
+    fn uuid_binds() {
+        let id = uuid::Uuid::nil();
+        let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+            .select(["id"])
+            .where_eq("id", id)
+            .to_sql();
+        assert_eq!(sql, r#"SELECT "id" FROM "t" WHERE "id" = $1"#);
+        assert_eq!(binds, vec![Value::Uuid(id)]);
+    }
+
+    #[test]
+    fn option_uuid_some_and_none() {
+        let id = uuid::Uuid::nil();
+        assert_eq!(Some(id).into_bind(), Value::Uuid(id));
+        assert_eq!(Option::<uuid::Uuid>::None.into_bind(), Value::Null);
+    }
+}
+
+#[cfg(feature = "chrono")]
+mod chrono_tests {
+    use chain_builder::{IntoBind, Postgres, QueryBuilder, Value};
+    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+    fn sample_dt_utc() -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap()
+    }
+
+    fn sample_naive_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 6, 9).unwrap()
+    }
+
+    fn sample_naive_time() -> NaiveTime {
+        NaiveTime::from_hms_opt(13, 30, 0).unwrap()
+    }
+
+    fn sample_naive_datetime() -> NaiveDateTime {
+        NaiveDateTime::new(sample_naive_date(), sample_naive_time())
+    }
+
+    #[test]
+    fn datetime_utc_into_bind() {
+        let dt = sample_dt_utc();
+        assert_eq!(dt.into_bind(), Value::DateTimeUtc(dt));
+    }
+
+    #[test]
+    fn naive_datetime_into_bind() {
+        let ndt = sample_naive_datetime();
+        assert_eq!(ndt.into_bind(), Value::NaiveDateTime(ndt));
+    }
+
+    #[test]
+    fn naive_date_into_bind() {
+        let nd = sample_naive_date();
+        assert_eq!(nd.into_bind(), Value::NaiveDate(nd));
+    }
+
+    #[test]
+    fn naive_time_into_bind() {
+        let nt = sample_naive_time();
+        assert_eq!(nt.into_bind(), Value::NaiveTime(nt));
+    }
+
+    #[test]
+    fn datetime_utc_binds() {
+        let dt = sample_dt_utc();
+        let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+            .select(["id"])
+            .where_eq("created_at", dt)
+            .to_sql();
+        assert_eq!(sql, r#"SELECT "id" FROM "t" WHERE "created_at" = $1"#);
+        assert_eq!(binds, vec![Value::DateTimeUtc(dt)]);
+    }
+
+    #[test]
+    fn naive_date_binds() {
+        let nd = sample_naive_date();
+        let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+            .select(["id"])
+            .where_eq("day", nd)
+            .to_sql();
+        assert_eq!(sql, r#"SELECT "id" FROM "t" WHERE "day" = $1"#);
+        assert_eq!(binds, vec![Value::NaiveDate(nd)]);
+    }
+
+    #[test]
+    fn option_chrono_none_becomes_null() {
+        assert_eq!(Option::<DateTime<Utc>>::None.into_bind(), Value::Null);
+        assert_eq!(Option::<NaiveDate>::None.into_bind(), Value::Null);
+    }
+}


### PR DESCRIPTION
Adds `Value::{Uuid,DateTimeUtc,NaiveDateTime,NaiveDate,NaiveTime}` + `IntoBind` behind `uuid`/`chrono` features (each pulls the matching `sqlx` feature). Bind `uuid::Uuid` / `chrono` types directly instead of converting to string. `bind_arguments` arms gated per type across all 3 dialects.

Verification: typebinds **10** · default **148** byte-identical (features off = no change) · all-3 **154** · clippy `-D warnings` clean (uuid,chrono,all dialects) · fmt clean · builds across feature combos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)