### PR TITLE
✨ M11: nested + OR groups in WhereBuilder

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -542,20 +542,6 @@ fn write_clause_list<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate<D>]) {
     }
 }
 
-/// Render a list of predicates joined by `conj` (used inside groups).
-fn write_preds<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate<D>], conj: Conj) {
-    let sep = match conj {
-        Conj::And => " AND ",
-        Conj::Or => " OR ",
-    };
-    for (i, p) in preds.iter().enumerate() {
-        if i > 0 {
-            ctx.sql.push_str(sep);
-        }
-        write_pred::<D>(ctx, p);
-    }
-}
-
 fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate<D>) {
     match pred {
         Predicate::Binary { col, op, val } => {
@@ -629,17 +615,21 @@ fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate<D>) {
             outer_conj: _,
             preds,
         } => {
-            // `outer_conj` controls how the group attaches to the preceding
-            // clause (handled in `write_clause_list`). Inner predicates are
-            // ALWAYS joined by `Conj::And` here: this is intentional for M1 —
-            // groups are flat AND-lists, and nested groups / inner-OR are a
-            // documented M1 limitation (see `WhereBuilder` docs, TG4).
+            // `outer_conj` controls how this group attaches to the *preceding*
+            // clause (handled in `write_clause_list`). The inner predicates are
+            // rendered with the SAME attach-conj logic as the top level
+            // (`write_clause_list`): each inner pred is joined with ` AND `
+            // unless it is itself a `Group` with `outer_conj == Conj::Or`, in
+            // which case it is joined with ` OR `. This enables M11 nested
+            // groups and inner-OR while staying byte-identical for the pre-M11
+            // case (a group whose preds are all non-`Group` predicates joins
+            // them all with ` AND `, exactly as the old hardcoded `Conj::And`).
             //
             // Empty groups never reach here: `write_clause_list` /
             // `write_wheres` filter them via `is_omitted` (F4), so we never
             // emit invalid `()`.
             ctx.sql.push('(');
-            write_preds::<D>(ctx, preds, Conj::And);
+            write_clause_list::<D>(ctx, preds);
             ctx.sql.push(')');
         }
         Predicate::Column { lhs, op, rhs } => {

--- a/src/where_.rs
+++ b/src/where_.rs
@@ -94,12 +94,14 @@ pub enum Predicate<D: Dialect> {
     /// A parenthesized group of predicates.
     ///
     /// `outer_conj` controls how the group attaches to the preceding clause
-    /// (`AND (...)` vs `OR (...)`). The predicates *inside* the group are
-    /// ALWAYS joined by `AND` in M1 — see the [`WhereBuilder`] limitation note.
+    /// (`AND (...)` vs `OR (...)`). Inner predicates are joined with `AND`,
+    /// except that a nested `Group` carries its own `outer_conj` (so `or_where`
+    /// inside a group emits ` OR (...)`) — groups nest arbitrarily.
     Group {
         /// How this group attaches to the preceding clause (outer separator).
         outer_conj: Conj,
-        /// Inner predicates (always `AND`-joined in M1).
+        /// Inner predicates; rendered like the top level, so nested groups with
+        /// `outer_conj: Or` introduce `OR` within this group.
         preds: Vec<Predicate<D>>,
     },
     /// `lhs op rhs` — both sides are column identifiers (escaped at compile
@@ -137,13 +139,9 @@ pub enum Predicate<D: Dialect> {
 /// The `PhantomData<D>` keeps the dialect in scope without threading the full
 /// builder through the closure.
 ///
-/// # M1 limitation
-///
-/// Groups in M1 are **non-nestable** and **flat-`AND`**: every predicate added
-/// inside the closure is joined to its siblings with `AND`, and there is no way
-/// to nest a further group or to `OR` predicates *within* a group. The only
-/// `OR` available is the *outer* attachment chosen by `or_where` (which emits
-/// `... OR (...)`). Nested groups and inner-`OR` are a documented M1 limitation.
+/// Siblings added directly are `AND`-joined; call `and_where`/`or_where` inside
+/// the closure to nest a further parenthesized group (and `or_where` introduces
+/// `OR` within the group). Nesting is arbitrary-depth.
 pub struct WhereBuilder<D: Dialect> {
     preds: Vec<Predicate<D>>,
     _marker: PhantomData<D>,
@@ -167,6 +165,26 @@ impl<D: Dialect> WhereBuilder<D> {
     /// Consume the accumulator and return the collected predicates.
     pub(crate) fn into_preds(self) -> Vec<Predicate<D>> {
         self.preds
+    }
+
+    fn group(
+        mut self,
+        outer_conj: Conj,
+        f: impl FnOnce(WhereBuilder<D>) -> WhereBuilder<D>,
+    ) -> Self {
+        let preds = f(WhereBuilder::new()).into_preds();
+        self.preds.push(Predicate::Group { outer_conj, preds });
+        self
+    }
+
+    /// Add a nested parenthesized `AND (...)` group built by the closure.
+    pub fn and_where(self, f: impl FnOnce(WhereBuilder<D>) -> WhereBuilder<D>) -> Self {
+        self.group(Conj::And, f)
+    }
+
+    /// Add a nested parenthesized `OR (...)` group built by the closure.
+    pub fn or_where(self, f: impl FnOnce(WhereBuilder<D>) -> WhereBuilder<D>) -> Self {
+        self.group(Conj::Or, f)
     }
 
     fn binary(mut self, col: &str, op: &'static str, val: impl IntoBind) -> Self {

--- a/tests/groups_nested.rs
+++ b/tests/groups_nested.rs
@@ -1,0 +1,98 @@
+//! M11 — nested groups + OR-inside-group.
+//!
+//! Verifies that `WhereBuilder` can nest further groups (via `and_where`/
+//! `or_where`) and that a `Predicate::Group` renders its inner predicates with
+//! each inner pred's own attach-conj (so a nested `or_where` group is joined
+//! with ` OR `). Existing flat-group output stays byte-identical.
+
+use chain_builder::{MySql, Postgres, QueryBuilder, Value};
+
+#[test]
+fn pg_or_inside_group() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .select(["*"])
+        .and_where(|g| g.where_eq("a", 1i64).or_where(|h| h.where_eq("b", 2i64)))
+        .to_sql();
+
+    assert_eq!(sql, r#"SELECT * FROM "t" WHERE ("a" = $1 OR ("b" = $2))"#);
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(2)]);
+}
+
+#[test]
+fn mysql_or_inside_group() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("t")
+        .select(["*"])
+        .and_where(|g| g.where_eq("a", 1i64).or_where(|h| h.where_eq("b", 2i64)))
+        .to_sql();
+
+    assert_eq!(sql, "SELECT * FROM `t` WHERE (`a` = ? OR (`b` = ?))");
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(2)]);
+}
+
+#[test]
+fn pg_nested_groups_property_pattern() {
+    let props = [("k1", "v1"), ("k2", "v2")];
+    let mut qb = QueryBuilder::<Postgres>::table("items").select(["id"]);
+    qb = qb.and_where(|outer| {
+        let mut w = outer;
+        for (k, v) in props {
+            w = w
+                .or_where(|g| {
+                    g.where_eq("properties_desc", k)
+                        .where_in("property_info", [v])
+                })
+                .or_where(|g| {
+                    g.where_eq("properties_desc2", k)
+                        .where_in("property_info2", [v])
+                });
+        }
+        w
+    });
+    let (sql, binds) = qb.to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "items" WHERE (("properties_desc" = $1 AND "property_info" IN ($2)) OR ("properties_desc2" = $3 AND "property_info2" IN ($4)) OR ("properties_desc" = $5 AND "property_info" IN ($6)) OR ("properties_desc2" = $7 AND "property_info2" IN ($8)))"#
+    );
+    assert_eq!(binds.len(), 8);
+    assert_eq!(
+        binds,
+        vec![
+            Value::Text("k1".into()),
+            Value::Text("v1".into()),
+            Value::Text("k1".into()),
+            Value::Text("v1".into()),
+            Value::Text("k2".into()),
+            Value::Text("v2".into()),
+            Value::Text("k2".into()),
+            Value::Text("v2".into()),
+        ]
+    );
+}
+
+/// Byte-identity regression: a flat `or_where`/`and_where` group (no nesting)
+/// must render exactly as it did pre-M11.
+#[test]
+fn pg_flat_groups_byte_identical() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .or_where(|g| g.where_eq("a", 1i64).where_eq("b", 2i64))
+        .and_where(|g| g.where_gt("c", 3i64).where_lt("d", 4i64))
+        .to_sql();
+
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "status" = $1 OR ("a" = $2 AND "b" = $3) AND ("c" > $4 AND "d" < $5)"#
+    );
+    assert_eq!(
+        binds,
+        vec![
+            Value::Text("active".into()),
+            Value::I64(1),
+            Value::I64(2),
+            Value::I64(3),
+            Value::I64(4),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
Closes the last 1.x-parity gap in WHERE grouping (the `where_subquery(|sub| … sub.or() …)` nested pattern). Folded into 2.0.0 (pre-publish). Into `main`.

- `WhereBuilder` gains `and_where`/`or_where` → **arbitrary-depth nested groups**.
- A `Group`'s inner predicates render via `write_clause_list`, so a nested `Group { outer_conj: Or }` emits `OR` **within** the group.
- **Backward-compatible**: pre-M11 flat groups contained only non-Group preds → still join with `AND`, byte-identical. Existing suites unchanged.

```rust
qb.and_where(|outer| {
    let mut w = outer;
    for (k, v) in props {
        w = w.or_where(|g| g.where_eq("desc",  k).where_in("info",  [v]))
             .or_where(|g| g.where_eq("desc2", k).where_in("info2", [v]));
    }
    w
});
// WHERE (("desc" = $1 AND "info" IN ($2)) OR ("desc2" = $1 ...) OR ...)
```

## Verification
`tests/groups_nested.rs` **4** (incl. the property pattern with `$1..$8` ordering) · default **152** (148 prior byte-identical + 4) · full **170** · clippy `-D warnings` clean · fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)