### PR TITLE
feat: Tier 1 — row locking, aggregate helpers, Value::Decimal (2.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Clippy
-        run: cargo clippy --features sqlx_postgres,sqlx_sqlite,uuid,chrono,json --all-targets -- -D warnings
+        run: cargo clippy --features sqlx_postgres,sqlx_sqlite,uuid,chrono,json,decimal --all-targets -- -D warnings
 
       - name: Build (no default features)
         run: cargo build --no-default-features
 
       - name: Test
-        run: cargo test --features sqlx_postgres,sqlx_sqlite,uuid,chrono,json
+        run: cargo test --features sqlx_postgres,sqlx_sqlite,uuid,chrono,json,decimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [2.1.0] - 2026-06-09
+
+### Added
+
+- **Row locking** — `for_update()` / `for_share()` plus `skip_locked()` /
+  `no_wait()` modifiers, rendered at the end of a `SELECT`. Honored by
+  Postgres / MySQL; a silent no-op on SQLite (which locks the whole database,
+  not rows). New `Dialect::supports_row_locking()` capability (default `true`,
+  SQLite overrides to `false`). Public types: `Lock`, `LockStrength`, `LockWait`.
+- **Aggregate SELECT helpers** — `select_count`/`select_sum`/`select_avg`/
+  `select_min`/`select_max` (+ `_as` aliased variants) and `select_as(col, alias)`
+  for plain column aliasing. Columns are escaped at compile time; `*` is passed
+  through (`COUNT(*)`). Restores the 1.x aggregate ergonomics. Public types:
+  `AggFn`, `SelectExpr`.
+- **`Value::Decimal` (`decimal` feature)** — bind `rust_decimal::Decimal` for
+  money / exact-numeric columns. Bound natively on Postgres (`NUMERIC`) and
+  MySQL (`DECIMAL`); bound as TEXT on SQLite (no native decimal type).
+
+### Notes
+
+- All additions are backwards compatible; existing generated SQL is unchanged
+  when the new builders are not used.
+
 ## [2.0.0] - 2026-06-09
 
 ### ⚠️ Breaking — complete rewrite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +33,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "atoi"
@@ -54,6 +71,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,10 +101,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -106,6 +181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,14 +194,15 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chain-builder"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "chrono",
+ "rust_decimal",
  "serde_json",
  "sqlx",
  "tokio",
@@ -264,7 +346,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -346,6 +428,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -448,9 +536,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -832,13 +929,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -848,6 +963,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -866,6 +1001,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,7 +1025,26 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -892,6 +1063,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1083,52 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -952,6 +1178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,7 +1216,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1038,6 +1270,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1110,6 +1348,7 @@ dependencies = [
  "log",
  "memchr",
  "percent-encoding",
+ "rust_decimal",
  "rustls",
  "serde",
  "serde_json",
@@ -1134,7 +1373,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1157,7 +1396,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "thiserror",
  "tokio",
  "url",
@@ -1182,6 +1421,7 @@ dependencies = [
  "generic-array",
  "log",
  "percent-encoding",
+ "rust_decimal",
  "serde",
  "sha1",
  "sha2 0.11.0",
@@ -1215,7 +1455,8 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.10.1",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1279,6 +1520,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -1296,8 +1548,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
@@ -1316,7 +1574,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1367,7 +1625,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1379,6 +1637,36 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -1401,7 +1689,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1531,6 +1819,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -1554,7 +1843,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1637,7 +1926,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1648,7 +1937,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1758,6 +2047,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,7 +2091,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1809,7 +2107,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1858,6 +2156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,8 +2183,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1897,7 +2224,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1937,7 +2264,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-builder"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 description = "A typed, dialect-aware SQL query builder for Rust (PostgreSQL/MySQL/SQLite)."
 license = "MIT"
@@ -19,6 +19,7 @@ sqlx = { version = "0.9" }
 serde_json = { version = "1", optional = true }
 uuid = { version = "1", optional = true }
 chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
+rust_decimal = { version = "1", optional = true }
 
 [dev-dependencies]
 sqlx = { version = "0.9", features = ["mysql", "sqlite", "postgres", "runtime-tokio", "tls-rustls"] }
@@ -32,3 +33,4 @@ sqlx_postgres = ["sqlx/postgres"]
 json = ["dep:serde_json"]
 uuid = ["dep:uuid", "sqlx/uuid"]
 chrono = ["dep:chrono", "sqlx/chrono"]
+decimal = ["dep:rust_decimal", "sqlx/rust_decimal"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ parameters, automatic identifier escaping, dialect-correct placeholders
 - **Full query surface** — SELECT/INSERT/UPDATE/DELETE, WHERE (+ `or`/`and` groups),
   JOINs, CTEs (`WITH`/`RECURSIVE`), `UNION`, GROUP BY/HAVING/ORDER BY, LIMIT/OFFSET.
 - **Upsert + RETURNING** — `on_conflict_merge`/`_do_nothing`, dialect-correct.
+- **Row locking** — `for_update`/`for_share` + `skip_locked`/`no_wait` (no-op on SQLite).
+- **Aggregates** — `select_count`/`sum`/`avg`/`min`/`max` (+ `_as`) and `select_as`.
 - **`db()` qualification** — multi-tenant (one connection, many databases).
 - **Typed fetch** — `fetch_all::<T>`/`fetch_one`/`count`/`fetch_scalar` via `sqlx`.
 - **Dynamic** — `when`/`when_else`, `paginate`, `distinct`/`distinct_on`, `ilike`, jsonb.
@@ -102,6 +104,9 @@ never pass untrusted input through them.
 - **`sqlx_sqlite`** — SQLite driver + `SqlxDialect for Sqlite`
 - **`sqlx_postgres`** — PostgreSQL driver + `SqlxDialect for Postgres`
 - **`json`** — `Value::Json` + `IntoBind for serde_json::Value`
+- **`uuid`** — `Value::Uuid` + `IntoBind for uuid::Uuid`
+- **`chrono`** — date/time `Value` variants + `IntoBind` for `chrono` types
+- **`decimal`** — `Value::Decimal` + `IntoBind for rust_decimal::Decimal`
 
 The query builder (`to_sql()`) works with **no** driver feature; a driver feature is
 only needed for the `sqlx` handoff (`to_sqlx_query`, `fetch_*`). All three drivers

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -34,9 +34,12 @@ let (sql, binds) = QueryBuilder::<Postgres>::table("users")
 ## Typed binds (`IntoBind` / `Value`)
 
 Bind arguments accept any `IntoBind`: integers, `f32`/`f64`, `bool`, `&str`/
-`String`, `Vec<u8>`/`&[u8]`, `Option<T>` (`None` → SQL `NULL`), and (with the
-`json` feature) `serde_json::Value`. They are stored in an internal `Value` enum
-and bound to `sqlx` with the right type — never inlined into SQL.
+`String`, `Vec<u8>`/`&[u8]`, `Option<T>` (`None` → SQL `NULL`), and the
+feature-gated types `serde_json::Value` (`json`), `uuid::Uuid` (`uuid`), the
+`chrono` date/time types (`chrono`), and `rust_decimal::Decimal` (`decimal`).
+They are stored in an internal `Value` enum and bound to `sqlx` with the right
+type — never inlined into SQL. `Decimal` binds natively on Postgres/MySQL and as
+TEXT on SQLite (which has no native decimal type).
 
 ## WHERE
 
@@ -58,8 +61,41 @@ Empty `IN ()` → `1 = 0`; empty `NOT IN ()` → `1 = 1`.
 ## SELECT / DISTINCT / aggregates
 
 `select([cols])` (bare identifiers, dotted ok), `select_raw(expr, binds)` for
-expressions (`COUNT(*)`, `... AS alias`), `distinct()`, `distinct_on([cols])`
-(Postgres only — panics elsewhere).
+arbitrary expressions, `distinct()`, `distinct_on([cols])` (Postgres only —
+panics elsewhere).
+
+Structured aggregate helpers escape the column at compile time (`*` passed
+through) and accept an optional alias via the `_as` variants:
+
+```rust
+QueryBuilder::<Postgres>::table("orders")
+    .select(["status"])
+    .select_count_as("*", "cnt")        // COUNT(*) AS "cnt"
+    .select_sum_as("amount", "total")   // SUM("amount") AS "total"
+    .group_by(["status"]);
+// SELECT "status", COUNT(*) AS "cnt", SUM("amount") AS "total" FROM "orders" GROUP BY "status"
+```
+
+`select_count`/`select_sum`/`select_avg`/`select_min`/`select_max` (no alias),
+their `_as` variants, and `select_as(col, alias)` for plain column aliasing.
+
+## Row locking
+
+`for_update()` / `for_share()` append a locking clause to a `SELECT`;
+`skip_locked()` / `no_wait()` add the corresponding modifier (and default the
+strength to `FOR UPDATE` if called alone). Honored by Postgres / MySQL; a
+**silent no-op on SQLite** (which locks the whole database, not rows) — ideal for
+job-queue / multi-tenant claim patterns:
+
+```rust
+QueryBuilder::<Postgres>::table("jobs")
+    .select(["id"])
+    .where_eq("status", "queued")
+    .limit(1)
+    .for_update()
+    .skip_locked();
+// SELECT "id" FROM "jobs" WHERE "status" = $1 LIMIT $2 FOR UPDATE SKIP LOCKED
+```
 
 ## JOIN / CTE / UNION
 
@@ -138,8 +174,9 @@ through raw methods.
 
 ## Known limitations
 
-- Live-DB integration tests require an `sqlx` runtime (the bundled tests are
-  compile-/string-level).
-- No `uuid` / `chrono` / `rust_decimal` `Value` variants yet (the enum is
-  `#[non_exhaustive]`); JSON path operators and named-constraint upsert targets
-  are not yet implemented.
+- Most bundled tests are string-level; a live `sqlite::memory:` round-trip test
+  exercises the real `sqlx` handoff.
+- JSON path operators, named-constraint upsert targets, derived tables
+  (subquery in `FROM`), and `INSERT … SELECT` are not yet implemented. The
+  `Value` enum is `#[non_exhaustive]`, so further variants can be added without a
+  breaking change.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -174,6 +174,90 @@ pub struct OnConflict {
     pub action: ConflictAction,
 }
 
+/// A SQL aggregate function for the `select_*` aggregate helpers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggFn {
+    /// `COUNT(...)`.
+    Count,
+    /// `SUM(...)`.
+    Sum,
+    /// `AVG(...)`.
+    Avg,
+    /// `MIN(...)`.
+    Min,
+    /// `MAX(...)`.
+    Max,
+}
+
+impl AggFn {
+    /// The uppercase SQL keyword for this function.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AggFn::Count => "COUNT",
+            AggFn::Sum => "SUM",
+            AggFn::Avg => "AVG",
+            AggFn::Min => "MIN",
+            AggFn::Max => "MAX",
+        }
+    }
+}
+
+/// A structured `SELECT`-list expression (aggregate or aliased column).
+///
+/// The `col`/`alias` identifiers are stored raw and escaped at compile time
+/// (a `*` column is emitted unescaped, e.g. `COUNT(*)`). Backs the `select_count`
+/// / `select_sum` / … and `select_as` helpers.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SelectExpr {
+    /// `FUNC(col)` with an optional `AS alias` — e.g. `COUNT(*) AS "total"`.
+    Agg {
+        /// The aggregate function.
+        func: AggFn,
+        /// Raw column identifier (escaped at compile time; `*` passed through).
+        col: String,
+        /// Optional alias (escaped at compile time).
+        alias: Option<String>,
+    },
+    /// `col AS alias` — both identifiers escaped at compile time.
+    ColAs {
+        /// Raw column identifier (escaped at compile time).
+        col: String,
+        /// Alias (escaped at compile time).
+        alias: String,
+    },
+}
+
+/// The strength of a row-locking clause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockStrength {
+    /// `FOR UPDATE` — exclusive lock.
+    Update,
+    /// `FOR SHARE` — shared lock.
+    Share,
+}
+
+/// The optional wait behavior of a row-locking clause.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockWait {
+    /// `SKIP LOCKED` — skip rows already locked.
+    SkipLocked,
+    /// `NOWAIT` — error immediately if a row is already locked.
+    NoWait,
+}
+
+/// A row-locking clause appended to a `SELECT` (`FOR UPDATE` / `FOR SHARE`,
+/// optionally `SKIP LOCKED` / `NOWAIT`).
+///
+/// Honored by Postgres / MySQL; a **silent no-op on SQLite** (see
+/// [`Dialect::supports_row_locking`](crate::Dialect::supports_row_locking)).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Lock {
+    /// `FOR UPDATE` vs `FOR SHARE`.
+    pub strength: LockStrength,
+    /// Optional `SKIP LOCKED` / `NOWAIT` modifier.
+    pub wait: Option<LockWait>,
+}
+
 /// Which kind of statement is being built.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Method {
@@ -196,6 +280,10 @@ pub struct QueryBuilder<D: Dialect> {
     /// When set, prefixes the main table and join tables: `"db"."table"`.
     pub(crate) db: Option<String>,
     pub(crate) select_cols: Vec<String>,
+    /// Structured `SELECT` expressions (aggregates / aliased columns), escaped at
+    /// compile time. Rendered after `select_cols`. Backs `select_count`/… /
+    /// `select_as`.
+    pub(crate) select_exprs: Vec<SelectExpr>,
     /// Raw `SELECT` expressions (verbatim, NOT escaped) with their own binds,
     /// appended after `select_cols`. Backs `select_raw`.
     pub(crate) select_raw: Vec<(String, Vec<Value>)>,
@@ -230,6 +318,8 @@ pub struct QueryBuilder<D: Dialect> {
     pub(crate) on_conflict: Option<OnConflict>,
     /// `RETURNING` column list (raw; `"*"` emitted unescaped).
     pub(crate) returning: Vec<String>,
+    /// Row-locking clause (`FOR UPDATE`/`FOR SHARE`); SELECT-only, no-op on SQLite.
+    pub(crate) lock: Option<Lock>,
     _marker: PhantomData<D>,
 }
 
@@ -240,6 +330,7 @@ impl<D: Dialect> QueryBuilder<D> {
             table: name.to_owned(),
             db: None,
             select_cols: Vec::new(),
+            select_exprs: Vec::new(),
             select_raw: Vec::new(),
             select_subqueries: Vec::new(),
             distinct: false,
@@ -260,6 +351,7 @@ impl<D: Dialect> QueryBuilder<D> {
             unions: Vec::new(),
             on_conflict: None,
             returning: Vec::new(),
+            lock: None,
             _marker: PhantomData,
         }
     }
@@ -311,6 +403,74 @@ impl<D: Dialect> QueryBuilder<D> {
     pub fn select_subquery(mut self, alias: &str, sub: QueryBuilder<D>) -> Self {
         self.select_subqueries
             .push((alias.to_owned(), Box::new(sub)));
+        self
+    }
+
+    fn push_agg(mut self, func: AggFn, col: &str, alias: Option<&str>) -> Self {
+        self.select_exprs.push(SelectExpr::Agg {
+            func,
+            col: col.to_owned(),
+            alias: alias.map(|a| a.to_owned()),
+        });
+        self
+    }
+
+    /// Add `COUNT(col)` to the SELECT list (`col == "*"` → `COUNT(*)`).
+    pub fn select_count(self, col: &str) -> Self {
+        self.push_agg(AggFn::Count, col, None)
+    }
+
+    /// Add `COUNT(col) AS alias` (both identifiers escaped; `*` passed through).
+    pub fn select_count_as(self, col: &str, alias: &str) -> Self {
+        self.push_agg(AggFn::Count, col, Some(alias))
+    }
+
+    /// Add `SUM(col)` to the SELECT list.
+    pub fn select_sum(self, col: &str) -> Self {
+        self.push_agg(AggFn::Sum, col, None)
+    }
+
+    /// Add `SUM(col) AS alias`.
+    pub fn select_sum_as(self, col: &str, alias: &str) -> Self {
+        self.push_agg(AggFn::Sum, col, Some(alias))
+    }
+
+    /// Add `AVG(col)` to the SELECT list.
+    pub fn select_avg(self, col: &str) -> Self {
+        self.push_agg(AggFn::Avg, col, None)
+    }
+
+    /// Add `AVG(col) AS alias`.
+    pub fn select_avg_as(self, col: &str, alias: &str) -> Self {
+        self.push_agg(AggFn::Avg, col, Some(alias))
+    }
+
+    /// Add `MIN(col)` to the SELECT list.
+    pub fn select_min(self, col: &str) -> Self {
+        self.push_agg(AggFn::Min, col, None)
+    }
+
+    /// Add `MIN(col) AS alias`.
+    pub fn select_min_as(self, col: &str, alias: &str) -> Self {
+        self.push_agg(AggFn::Min, col, Some(alias))
+    }
+
+    /// Add `MAX(col)` to the SELECT list.
+    pub fn select_max(self, col: &str) -> Self {
+        self.push_agg(AggFn::Max, col, None)
+    }
+
+    /// Add `MAX(col) AS alias`.
+    pub fn select_max_as(self, col: &str, alias: &str) -> Self {
+        self.push_agg(AggFn::Max, col, Some(alias))
+    }
+
+    /// Add `col AS alias` to the SELECT list (both identifiers escaped).
+    pub fn select_as(mut self, col: &str, alias: &str) -> Self {
+        self.select_exprs.push(SelectExpr::ColAs {
+            col: col.to_owned(),
+            alias: alias.to_owned(),
+        });
         self
     }
 
@@ -750,6 +910,64 @@ impl<D: Dialect> QueryBuilder<D> {
     /// rejects a bare `OFFSET`.
     pub fn offset(mut self, n: i64) -> Self {
         self.offset = Some(n);
+        self
+    }
+
+    /// Lock selected rows with `FOR UPDATE`. SELECT-only.
+    ///
+    /// Honored by Postgres / MySQL; a **silent no-op on SQLite**. Preserves any
+    /// `SKIP LOCKED` / `NOWAIT` modifier already set.
+    pub fn for_update(mut self) -> Self {
+        let wait = self.lock.and_then(|l| l.wait);
+        self.lock = Some(Lock {
+            strength: LockStrength::Update,
+            wait,
+        });
+        self
+    }
+
+    /// Lock selected rows with `FOR SHARE`. SELECT-only.
+    ///
+    /// Honored by Postgres / MySQL; a **silent no-op on SQLite**. Preserves any
+    /// `SKIP LOCKED` / `NOWAIT` modifier already set.
+    pub fn for_share(mut self) -> Self {
+        let wait = self.lock.and_then(|l| l.wait);
+        self.lock = Some(Lock {
+            strength: LockStrength::Share,
+            wait,
+        });
+        self
+    }
+
+    /// Add `SKIP LOCKED` to the row-locking clause (skip already-locked rows).
+    ///
+    /// If no lock strength was set yet, defaults to `FOR UPDATE`. SELECT-only;
+    /// no-op on SQLite.
+    pub fn skip_locked(mut self) -> Self {
+        let strength = self
+            .lock
+            .map(|l| l.strength)
+            .unwrap_or(LockStrength::Update);
+        self.lock = Some(Lock {
+            strength,
+            wait: Some(LockWait::SkipLocked),
+        });
+        self
+    }
+
+    /// Add `NOWAIT` to the row-locking clause (error if a row is already locked).
+    ///
+    /// If no lock strength was set yet, defaults to `FOR UPDATE`. SELECT-only;
+    /// no-op on SQLite.
+    pub fn no_wait(mut self) -> Self {
+        let strength = self
+            .lock
+            .map(|l| l.strength)
+            .unwrap_or(LockStrength::Update);
+        self.lock = Some(Lock {
+            strength,
+            wait: Some(LockWait::NoWait),
+        });
         self
     }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -6,7 +6,8 @@
 //! across nested groups) while MySQL/SQLite yield `?`.
 
 use crate::builder::{
-    ConflictAction, Cte, Having, Join, JoinCond, JoinKind, Method, Order, QueryBuilder,
+    ConflictAction, Cte, Having, Join, JoinCond, JoinKind, Lock, LockStrength, LockWait, Method,
+    Order, QueryBuilder, SelectExpr,
 };
 use crate::dialect::{Dialect, UpsertStyle};
 use crate::ident::escape_identifier;
@@ -97,6 +98,7 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             write_order_by(ctx, &qb.orders, qb.order_by_raw.as_ref());
             write_limit_offset::<D>(ctx, qb.limit, qb.offset);
             write_unions::<D>(ctx, &qb.unions);
+            write_lock::<D>(ctx, qb.lock.as_ref());
         }
         Method::Insert => {
             if qb.set.is_empty() && qb.insert_rows.is_empty() {
@@ -306,7 +308,11 @@ fn write_group_by(ctx: &mut Ctx, groups: &[String], raw: Option<&(String, Vec<Va
 /// Written directly into `ctx` (not pre-joined) so subquery binds continue the
 /// placeholder counter in emission order.
 fn write_select_list<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
-    if qb.select_cols.is_empty() && qb.select_raw.is_empty() && qb.select_subqueries.is_empty() {
+    if qb.select_cols.is_empty()
+        && qb.select_exprs.is_empty()
+        && qb.select_raw.is_empty()
+        && qb.select_subqueries.is_empty()
+    {
         ctx.sql.push('*');
         return;
     }
@@ -317,6 +323,38 @@ fn write_select_list<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
         }
         let e = ctx.esc(c);
         ctx.sql.push_str(&e);
+        wrote_any = true;
+    }
+    for expr in &qb.select_exprs {
+        if wrote_any {
+            ctx.sql.push_str(", ");
+        }
+        match expr {
+            SelectExpr::Agg { func, col, alias } => {
+                ctx.sql.push_str(func.as_str());
+                ctx.sql.push('(');
+                // A `*` column is emitted unescaped (`COUNT(*)`).
+                if col == "*" {
+                    ctx.sql.push('*');
+                } else {
+                    let c = ctx.esc(col);
+                    ctx.sql.push_str(&c);
+                }
+                ctx.sql.push(')');
+                if let Some(a) = alias {
+                    let a = ctx.esc(a);
+                    ctx.sql.push_str(" AS ");
+                    ctx.sql.push_str(&a);
+                }
+            }
+            SelectExpr::ColAs { col, alias } => {
+                let c = ctx.esc(col);
+                let a = ctx.esc(alias);
+                ctx.sql.push_str(&c);
+                ctx.sql.push_str(" AS ");
+                ctx.sql.push_str(&a);
+            }
+        }
         wrote_any = true;
     }
     for (sql, binds) in &qb.select_raw {
@@ -498,6 +536,29 @@ fn write_limit_offset<D: Dialect>(ctx: &mut Ctx, limit: Option<i64>, offset: Opt
     if let Some(n) = offset {
         ctx.sql.push_str(" OFFSET ");
         ctx.placeholder::<D>(Value::I64(n));
+    }
+}
+
+/// Render a row-locking clause (` FOR UPDATE`/` FOR SHARE` [+ ` SKIP LOCKED`/
+/// ` NOWAIT`]) at the end of a `SELECT`. A **no-op on dialects without row
+/// locking** (SQLite), so the lock is silently dropped there rather than
+/// producing invalid SQL.
+fn write_lock<D: Dialect>(ctx: &mut Ctx, lock: Option<&Lock>) {
+    let Some(lock) = lock else {
+        return;
+    };
+    if !D::supports_row_locking() {
+        return;
+    }
+    ctx.sql.push_str(match lock.strength {
+        LockStrength::Update => " FOR UPDATE",
+        LockStrength::Share => " FOR SHARE",
+    });
+    if let Some(wait) = lock.wait {
+        ctx.sql.push_str(match wait {
+            LockWait::SkipLocked => " SKIP LOCKED",
+            LockWait::NoWait => " NOWAIT",
+        });
     }
 }
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -58,6 +58,14 @@ pub trait Dialect: Sized + Send + Sync + 'static {
     fn ilike_is_native() -> bool {
         false
     }
+
+    /// Whether this dialect supports row-locking clauses (`FOR UPDATE` /
+    /// `FOR SHARE`, optionally `SKIP LOCKED` / `NOWAIT`). Defaults to `true`
+    /// (Postgres / MySQL); SQLite overrides to `false`, where such clauses are a
+    /// silent no-op (SQLite locks the whole database, not rows).
+    fn supports_row_locking() -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -18,4 +18,8 @@ impl Dialect for Sqlite {
     fn supports_returning() -> bool {
         true
     }
+
+    fn supports_row_locking() -> bool {
+        false
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@ pub mod fetch;
 pub mod sqlx_bind;
 
 pub use builder::{
-    ConflictAction, Cte, Having, Join, JoinClause, JoinCond, JoinKind, Method, OnConflict, Order,
-    QueryBuilder,
+    AggFn, ConflictAction, Cte, Having, Join, JoinClause, JoinCond, JoinKind, Lock, LockStrength,
+    LockWait, Method, OnConflict, Order, QueryBuilder, SelectExpr,
 };
 pub use compile::compile;
 pub use dialect::{Dialect, MySql, Postgres, Sqlite, UpsertStyle};

--- a/src/sqlx_bind.rs
+++ b/src/sqlx_bind.rs
@@ -106,6 +106,11 @@ impl SqlxDialect for Postgres {
                 Value::NaiveTime(t) => {
                     let _ = arguments.add(*t);
                 }
+                #[cfg(feature = "decimal")]
+                Value::Decimal(d) => {
+                    // Native NUMERIC on Postgres.
+                    let _ = arguments.add(*d);
+                }
             }
         }
         arguments
@@ -164,6 +169,11 @@ impl SqlxDialect for MySql {
                 #[cfg(feature = "chrono")]
                 Value::NaiveTime(t) => {
                     let _ = arguments.add(*t);
+                }
+                #[cfg(feature = "decimal")]
+                Value::Decimal(d) => {
+                    // Native DECIMAL on MySQL.
+                    let _ = arguments.add(*d);
                 }
             }
         }
@@ -225,6 +235,12 @@ impl SqlxDialect for Sqlite {
                 #[cfg(feature = "chrono")]
                 Value::NaiveTime(t) => {
                     let _ = arguments.add(*t);
+                }
+                #[cfg(feature = "decimal")]
+                Value::Decimal(d) => {
+                    // SQLite has no native decimal type and sqlx provides no
+                    // `Decimal` encoder for it, so bind the exact value as TEXT.
+                    let _ = arguments.add(d.to_string());
                 }
             }
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -41,6 +41,11 @@ pub enum Value {
     /// Naive time of day (requires the `chrono` feature).
     #[cfg(feature = "chrono")]
     NaiveTime(chrono::NaiveTime),
+    /// Fixed-point decimal for money/exact-numeric columns (requires the
+    /// `decimal` feature). Bound natively on Postgres/MySQL (`NUMERIC`/`DECIMAL`)
+    /// and as TEXT on SQLite (which has no native decimal type).
+    #[cfg(feature = "decimal")]
+    Decimal(rust_decimal::Decimal),
 }
 
 /// Conversion of a Rust value into a bound [`Value`].
@@ -179,6 +184,13 @@ impl IntoBind for chrono::NaiveDate {
 impl IntoBind for chrono::NaiveTime {
     fn into_bind(self) -> Value {
         Value::NaiveTime(self)
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl IntoBind for rust_decimal::Decimal {
+    fn into_bind(self) -> Value {
+        Value::Decimal(self)
     }
 }
 

--- a/tests/aggregates.rs
+++ b/tests/aggregates.rs
@@ -1,0 +1,85 @@
+//! Aggregate SELECT helpers (`select_count`/`sum`/`avg`/`min`/`max` + `_as`)
+//! and plain column aliasing (`select_as`).
+
+use chain_builder::{MySql, Postgres, QueryBuilder};
+
+#[test]
+fn count_star_pg() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select_count("*")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT COUNT(*) FROM "users""#);
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn count_column_is_escaped() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("users")
+        .select_count("id")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT COUNT("id") FROM "users""#);
+}
+
+#[test]
+fn count_as_alias() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("users")
+        .select_count_as("*", "total")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT COUNT(*) AS "total" FROM "users""#);
+}
+
+#[test]
+fn all_aggregates_pg() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("orders")
+        .select_sum("amount")
+        .select_avg("amount")
+        .select_min("amount")
+        .select_max("amount")
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT SUM("amount"), AVG("amount"), MIN("amount"), MAX("amount") FROM "orders""#
+    );
+}
+
+#[test]
+fn aggregate_with_group_by_and_alias() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("orders")
+        .select(["status"])
+        .select_count_as("*", "cnt")
+        .select_sum_as("amount", "total")
+        .group_by(["status"])
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "status", COUNT(*) AS "cnt", SUM("amount") AS "total" FROM "orders" GROUP BY "status""#
+    );
+}
+
+#[test]
+fn select_as_plain_alias() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("users")
+        .select_as("created_at", "joined")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "created_at" AS "joined" FROM "users""#);
+}
+
+#[test]
+fn aggregates_use_backticks_on_mysql() {
+    let (sql, _) = QueryBuilder::<MySql>::table("orders")
+        .select_count_as("id", "cnt")
+        .select_max("price")
+        .to_sql();
+    assert_eq!(
+        sql,
+        "SELECT COUNT(`id`) AS `cnt`, MAX(`price`) FROM `orders`"
+    );
+}
+
+#[test]
+fn qualified_column_in_aggregate() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("orders")
+        .select_sum("orders.amount")
+        .to_sql();
+    assert_eq!(sql, r#"SELECT SUM("orders"."amount") FROM "orders""#);
+}

--- a/tests/decimal.rs
+++ b/tests/decimal.rs
@@ -1,0 +1,29 @@
+//! `Value::Decimal` binding (requires the `decimal` feature).
+#![cfg(feature = "decimal")]
+
+use std::str::FromStr;
+
+use chain_builder::{IntoBind, Postgres, QueryBuilder, Value};
+use rust_decimal::Decimal;
+
+#[test]
+fn decimal_into_bind() {
+    let d = Decimal::from_str("19.99").unwrap();
+    assert_eq!(d.into_bind(), Value::Decimal(d));
+}
+
+#[test]
+fn decimal_binds_as_placeholder() {
+    let price = Decimal::from_str("19.99").unwrap();
+    let (sql, binds) = QueryBuilder::<Postgres>::table("products")
+        .select(["id"])
+        .where_eq("price", price)
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "products" WHERE "price" = $1"#);
+    assert_eq!(binds, vec![Value::Decimal(price)]);
+}
+
+#[test]
+fn decimal_option_none_is_null() {
+    assert_eq!(Option::<Decimal>::None.into_bind(), Value::Null);
+}

--- a/tests/locking.rs
+++ b/tests/locking.rs
@@ -1,0 +1,102 @@
+//! Row-locking clauses (`FOR UPDATE` / `FOR SHARE`, `SKIP LOCKED` / `NOWAIT`).
+
+use chain_builder::{MySql, Postgres, QueryBuilder, Sqlite};
+
+#[test]
+fn for_update_pg() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("jobs")
+        .select(["id"])
+        .where_eq("status", "queued")
+        .for_update()
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "jobs" WHERE "status" = $1 FOR UPDATE"#
+    );
+}
+
+#[test]
+fn for_share_pg() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("jobs")
+        .select(["id"])
+        .for_share()
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "jobs" FOR SHARE"#);
+}
+
+#[test]
+fn for_update_skip_locked() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("jobs")
+        .select(["id"])
+        .for_update()
+        .skip_locked()
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "jobs" FOR UPDATE SKIP LOCKED"#);
+}
+
+#[test]
+fn for_update_nowait() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("jobs")
+        .select(["id"])
+        .for_update()
+        .no_wait()
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "jobs" FOR UPDATE NOWAIT"#);
+}
+
+#[test]
+fn skip_locked_defaults_to_for_update() {
+    // Calling skip_locked() without a prior for_update()/for_share() defaults the
+    // strength to FOR UPDATE (the job-queue idiom).
+    let (sql, _) = QueryBuilder::<Postgres>::table("jobs")
+        .select(["id"])
+        .skip_locked()
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "jobs" FOR UPDATE SKIP LOCKED"#);
+}
+
+#[test]
+fn lock_after_limit() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("jobs")
+        .select(["id"])
+        .limit(1)
+        .for_update()
+        .skip_locked()
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "jobs" LIMIT $1 FOR UPDATE SKIP LOCKED"#
+    );
+    assert_eq!(binds.len(), 1);
+}
+
+#[test]
+fn for_update_mysql() {
+    let (sql, _) = QueryBuilder::<MySql>::table("jobs")
+        .select(["id"])
+        .for_update()
+        .skip_locked()
+        .to_sql();
+    assert_eq!(sql, "SELECT `id` FROM `jobs` FOR UPDATE SKIP LOCKED");
+}
+
+#[test]
+fn locking_is_noop_on_sqlite() {
+    // SQLite locks the whole database, not rows: the clause is silently dropped.
+    let (sql, _) = QueryBuilder::<Sqlite>::table("jobs")
+        .select(["id"])
+        .for_update()
+        .skip_locked()
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "jobs""#);
+}
+
+#[test]
+fn for_share_then_skip_locked_preserves_strength() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("jobs")
+        .select(["id"])
+        .for_share()
+        .skip_locked()
+        .to_sql();
+    assert_eq!(sql, r#"SELECT "id" FROM "jobs" FOR SHARE SKIP LOCKED"#);
+}


### PR DESCRIPTION
## Tier 1 feature bundle → **2.1.0**

Three additive features closing the highest-value gaps after 2.0.0.

### 🔒 Row locking
- `for_update()` / `for_share()` + `skip_locked()` / `no_wait()` modifiers, rendered at the end of a `SELECT`.
- Honored by Postgres / MySQL; **silent no-op on SQLite** (locks the whole DB, not rows).
- New `Dialect::supports_row_locking()` (default `true`; SQLite overrides `false`).
- Public types: `Lock`, `LockStrength`, `LockWait`.

### Σ Aggregate SELECT helpers
- `select_count`/`sum`/`avg`/`min`/`max` (+ `_as` aliased variants) and `select_as(col, alias)`.
- Columns escaped at compile time (escape-in-compile invariant preserved); `*` passed through (`COUNT(*)`). Restores 1.x ergonomics.
- Public types: `AggFn`, `SelectExpr`.

### 💰 `Value::Decimal` (`decimal` feature)
- Bind `rust_decimal::Decimal`. Native `NUMERIC`/`DECIMAL` on Postgres/MySQL; bound as TEXT on SQLite (no native decimal type).

### Compatibility
- Fully additive — existing generated SQL is unchanged when the new builders are not used.

### Verification
- Tests **+20** (aggregates 8, locking 9, decimal 3); full suite green.
- `cargo fmt --check` clean; `cargo clippy -D warnings` clean with full features (incl `decimal`).
- Compiles: `--no-default-features`, `decimal` alone, and the publish.yml combo (`sqlx_postgres,sqlx_sqlite`, no decimal — match stays exhaustive).
- CI feature lists updated to include `decimal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)