### PR TITLE
fix: row locking fails loud on misuse (2.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.1.1] - 2026-06-09
+
+### Changed
+
+- **Row locking now fails loud on misuse** instead of silently doing the wrong
+  thing (scrutinize follow-up to 2.1.0):
+  - A lock (`for_update`/`for_share`) attached to a non-`SELECT` statement now
+    **panics** at compile time. Previously it was silently dropped — a dangerous
+    no-op for a lock (the caller believes rows are locked when they are not).
+  - A lock combined with `UNION` on a locking dialect (Postgres/MySQL) now
+    **panics** rather than emitting SQL those engines reject. SQLite (which
+    no-ops locks entirely) is unaffected — lock+UNION stays a harmless no-op there.
+  Both guards match the existing `offset`-without-`limit` / `distinct_on`
+  panics. Valid `SELECT` locking is unchanged.
+
 ## [2.1.0] - 2026-06-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "chain-builder"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "rust_decimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-builder"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "A typed, dialect-aware SQL query builder for Rust (PostgreSQL/MySQL/SQLite)."
 license = "MIT"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -250,6 +250,9 @@ pub enum LockWait {
 ///
 /// Honored by Postgres / MySQL; a **silent no-op on SQLite** (see
 /// [`Dialect::supports_row_locking`](crate::Dialect::supports_row_locking)).
+/// Compiling panics if a lock is attached to a non-`SELECT` statement (a
+/// dangerous silent no-op otherwise) or combined with `UNION` on a locking
+/// dialect (invalid SQL).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Lock {
     /// `FOR UPDATE` vs `FOR SHARE`.
@@ -913,10 +916,11 @@ impl<D: Dialect> QueryBuilder<D> {
         self
     }
 
-    /// Lock selected rows with `FOR UPDATE`. SELECT-only.
+    /// Lock selected rows with `FOR UPDATE`.
     ///
     /// Honored by Postgres / MySQL; a **silent no-op on SQLite**. Preserves any
-    /// `SKIP LOCKED` / `NOWAIT` modifier already set.
+    /// `SKIP LOCKED` / `NOWAIT` modifier already set. **SELECT-only:** compiling
+    /// panics if attached to INSERT/UPDATE/DELETE or combined with `UNION`.
     pub fn for_update(mut self) -> Self {
         let wait = self.lock.and_then(|l| l.wait);
         self.lock = Some(Lock {
@@ -926,10 +930,11 @@ impl<D: Dialect> QueryBuilder<D> {
         self
     }
 
-    /// Lock selected rows with `FOR SHARE`. SELECT-only.
+    /// Lock selected rows with `FOR SHARE`.
     ///
     /// Honored by Postgres / MySQL; a **silent no-op on SQLite**. Preserves any
-    /// `SKIP LOCKED` / `NOWAIT` modifier already set.
+    /// `SKIP LOCKED` / `NOWAIT` modifier already set. **SELECT-only:** compiling
+    /// panics if attached to INSERT/UPDATE/DELETE or combined with `UNION`.
     pub fn for_share(mut self) -> Self {
         let wait = self.lock.and_then(|l| l.wait);
         self.lock = Some(Lock {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -71,6 +71,14 @@ pub fn compile<D: Dialect>(qb: &QueryBuilder<D>) -> (String, Vec<Value>) {
 fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
     let table = ctx.qualify(qb.db.as_deref(), &qb.table);
 
+    // A row lock is only meaningful on SELECT. Attaching one to INSERT/UPDATE/
+    // DELETE would otherwise be silently dropped — a dangerous no-op for a lock
+    // (the caller believes rows are locked when they are not). Fail loud,
+    // dialect-independent, like the `offset`/`distinct_on` guards.
+    if qb.lock.is_some() && qb.method != Method::Select {
+        panic!("for_update()/for_share() is only valid on SELECT");
+    }
+
     match qb.method {
         Method::Select => {
             // CTEs are emitted first so their binds (and pg `$N`) come first.
@@ -98,7 +106,7 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             write_order_by(ctx, &qb.orders, qb.order_by_raw.as_ref());
             write_limit_offset::<D>(ctx, qb.limit, qb.offset);
             write_unions::<D>(ctx, &qb.unions);
-            write_lock::<D>(ctx, qb.lock.as_ref());
+            write_lock::<D>(ctx, qb.lock.as_ref(), !qb.unions.is_empty());
         }
         Method::Insert => {
             if qb.set.is_empty() && qb.insert_rows.is_empty() {
@@ -542,13 +550,20 @@ fn write_limit_offset<D: Dialect>(ctx: &mut Ctx, limit: Option<i64>, offset: Opt
 /// Render a row-locking clause (` FOR UPDATE`/` FOR SHARE` [+ ` SKIP LOCKED`/
 /// ` NOWAIT`]) at the end of a `SELECT`. A **no-op on dialects without row
 /// locking** (SQLite), so the lock is silently dropped there rather than
-/// producing invalid SQL.
-fn write_lock<D: Dialect>(ctx: &mut Ctx, lock: Option<&Lock>) {
+/// producing invalid SQL. Panics if a lock is combined with `UNION` on a
+/// locking dialect (Postgres/MySQL reject that combination).
+fn write_lock<D: Dialect>(ctx: &mut Ctx, lock: Option<&Lock>, has_unions: bool) {
     let Some(lock) = lock else {
         return;
     };
     if !D::supports_row_locking() {
         return;
+    }
+    // Postgres/MySQL reject `FOR UPDATE`/`FOR SHARE` on a `UNION` result; emitting
+    // it would produce invalid SQL, so fail loud here. (No-op dialects returned
+    // above never reach this, so a SQLite lock+UNION stays a harmless no-op.)
+    if has_unions {
+        panic!("for_update()/for_share() cannot be combined with UNION");
     }
     ctx.sql.push_str(match lock.strength {
         LockStrength::Update => " FOR UPDATE",

--- a/tests/locking.rs
+++ b/tests/locking.rs
@@ -100,3 +100,59 @@ fn for_share_then_skip_locked_preserves_strength() {
         .to_sql();
     assert_eq!(sql, r#"SELECT "id" FROM "jobs" FOR SHARE SKIP LOCKED"#);
 }
+
+#[test]
+#[should_panic(expected = "only valid on SELECT")]
+fn lock_on_delete_panics() {
+    // A lock on a non-SELECT is a dangerous silent no-op — fail loud instead.
+    let _ = QueryBuilder::<Postgres>::table("jobs")
+        .delete()
+        .for_update()
+        .to_sql();
+}
+
+#[test]
+#[should_panic(expected = "only valid on SELECT")]
+fn lock_on_update_panics() {
+    let _ = QueryBuilder::<Postgres>::table("jobs")
+        .update([("status", "done")])
+        .for_update()
+        .to_sql();
+}
+
+#[test]
+#[should_panic(expected = "only valid on SELECT")]
+fn lock_on_non_select_panics_on_sqlite_too() {
+    // Dialect-independent: the misuse is structural, not a dialect capability.
+    let _ = QueryBuilder::<Sqlite>::table("jobs")
+        .delete()
+        .for_update()
+        .to_sql();
+}
+
+#[test]
+#[should_panic(expected = "cannot be combined with UNION")]
+fn lock_with_union_panics() {
+    // Postgres/MySQL reject FOR UPDATE on a UNION result — fail loud.
+    let arm = QueryBuilder::<Postgres>::table("archived_jobs").select(["id"]);
+    let _ = QueryBuilder::<Postgres>::table("jobs")
+        .select(["id"])
+        .for_update()
+        .union(arm)
+        .to_sql();
+}
+
+#[test]
+fn lock_with_union_is_noop_on_sqlite() {
+    // SQLite drops the lock entirely, so lock+UNION stays a harmless no-op there.
+    let arm = QueryBuilder::<Sqlite>::table("archived_jobs").select(["id"]);
+    let (sql, _) = QueryBuilder::<Sqlite>::table("jobs")
+        .select(["id"])
+        .for_update()
+        .union(arm)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "jobs" UNION SELECT "id" FROM "archived_jobs""#
+    );
+}


### PR DESCRIPTION
Scrutinize follow-ups to 2.1.0. Two row-locking footguns now **panic at compile time** (matching the existing `offset`/`distinct_on` guards) instead of silently doing the wrong thing:

- **Lock on a non-SELECT** (`for_update().delete()`) was silently dropped — a dangerous no-op for a lock (caller believes rows are locked when they are not). Now panics `"for_update()/for_share() is only valid on SELECT"`. Dialect-independent (structural misuse).
- **Lock + UNION** on pg/mysql (which reject the combination) emitted invalid SQL. Now panics `"... cannot be combined with UNION"`. Gated behind `supports_row_locking`, so SQLite stays a harmless no-op.

Valid `SELECT` locking is unchanged (no SQL/behavior change for correct usage).

Tests +5 (locking 9 → 14); full suite green; fmt/clippy(`-D warnings`, all features) clean. Version → **2.1.1**, CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)