### PR TITLE
fix: having() operator allowlist (SQL-injection guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- **`having()` now validates its operator against an allowlist** instead of
+  emitting it verbatim. The operator argument is `op: &str` (for ergonomics),
+  unlike `where_eq`/`where_column`/`JoinClause::on` which take `&'static str`
+  and so only accept compile-time literals. Because `having`'s operator is
+  written directly into the SQL (it is not a bound value), an
+  attacker-controlled operator — e.g. from a generic `{field, op, value}` filter
+  API — was a SQL-injection vector. The operator is now matched
+  case-insensitively against `=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `LIKE`,
+  `NOT LIKE`; anything else **panics** (fail-loud, like the `offset`/
+  `distinct_on`/lock guards). Use `having_raw()` for arbitrary aggregate
+  expressions. Non-breaking: every existing call using a standard comparison
+  operator keeps working unchanged.
+
 ## [2.1.1] - 2026-06-09
 
 ### Changed

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1033,10 +1033,38 @@ impl<D: Dialect> QueryBuilder<D> {
     /// For aggregate expressions like `COUNT(*) > ?`, use [`Self::having_raw`].
     /// SELECT-only: ignored for INSERT/UPDATE/DELETE. Multiple HAVING terms are
     /// joined by `AND`.
+    ///
+    /// # Operator allowlist (injection guard)
+    ///
+    /// Unlike `where_eq`/`where_column`/`JoinClause::on`, which take
+    /// `op: &'static str` (so only compile-time literals are accepted), this
+    /// method takes `op: &str` for ergonomics. Because `op` is emitted
+    /// **verbatim** into the SQL (it is not a bound value and cannot be escaped
+    /// without changing its meaning), an attacker-controlled operator would be a
+    /// SQL-injection vector. To prevent that, `op` is validated against a fixed
+    /// set of comparison operators and a disallowed operator **panics**
+    /// (fail-loud, like the `offset`/`distinct_on`/lock guards). The operator is
+    /// matched case-insensitively and stored trimmed. For anything outside this
+    /// set — arbitrary aggregate expressions, custom operators — use
+    /// [`Self::having_raw`], the documented verbatim escape hatch.
+    ///
+    /// Allowed: `=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `LIKE`, `NOT LIKE`.
     pub fn having(mut self, col: &str, op: &str, val: impl IntoBind) -> Self {
+        const ALLOWED_HAVING_OPS: &[&str] =
+            &["=", "!=", "<>", ">", ">=", "<", "<=", "LIKE", "NOT LIKE"];
+        let normalized = op.trim();
+        if !ALLOWED_HAVING_OPS
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(normalized))
+        {
+            panic!(
+                "having() operator {op:?} is not an allowed comparison operator \
+                 (use having_raw() for arbitrary aggregate expressions)"
+            );
+        }
         self.havings.push(Having::Col {
             col: col.to_owned(),
-            op: op.to_owned(),
+            op: normalized.to_owned(),
             val: val.into_bind(),
         });
         self

--- a/tests/having_guard.rs
+++ b/tests/having_guard.rs
@@ -1,0 +1,59 @@
+//! `having()` operator allowlist guard.
+//!
+//! Unlike every other operator-bearing method (`where_eq`, `where_column`,
+//! `JoinClause::on`, …) which take `op: &'static str` and so cannot receive a
+//! runtime string, `having()` takes `op: &str` for ergonomics. To keep that
+//! from becoming a SQL-injection vector when a caller wires an
+//! attacker-controlled operator into the HAVING clause, the operator is
+//! validated against a fixed allowlist and a disallowed operator panics
+//! (fail-loud, matching the `offset`/`distinct_on`/lock guards). Arbitrary
+//! aggregate expressions go through `having_raw` instead.
+
+use chain_builder::{Postgres, QueryBuilder};
+
+#[test]
+fn allowed_operators_compile() {
+    for op in ["=", "!=", "<>", ">", ">=", "<", "<=", "LIKE", "NOT LIKE"] {
+        let (sql, _) = QueryBuilder::<Postgres>::table("orders")
+            .select(["user_id"])
+            .group_by(["user_id"])
+            .having("total", op, 100i64)
+            .to_sql();
+        assert_eq!(
+            sql,
+            format!(r#"SELECT "user_id" FROM "orders" GROUP BY "user_id" HAVING "total" {op} $1"#)
+        );
+    }
+}
+
+#[test]
+fn operator_is_case_insensitive_and_trimmed() {
+    // `like` (lowercase, padded) is accepted and stored trimmed.
+    let (sql, _) = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .having("name", "  like  ", "a%")
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "user_id" FROM "orders" HAVING "name" like $1"#
+    );
+}
+
+#[test]
+#[should_panic(expected = "not an allowed")]
+fn injection_via_operator_panics() {
+    // The classic generic-filter-API injection: an attacker-controlled operator.
+    let _ = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .having("amount", ">= 0 UNION SELECT password FROM users --", 0i64)
+        .to_sql();
+}
+
+#[test]
+#[should_panic(expected = "not an allowed")]
+fn arbitrary_operator_panics() {
+    let _ = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .having("amount", "; DROP TABLE users", 0i64)
+        .to_sql();
+}


### PR DESCRIPTION
## Security fix

`having(col, op, val)` took `op: &str` and emitted it **verbatim** into the SQL — unlike `where_eq` / `where_column` / `JoinClause::on`, which take `op: &'static str` and so only accept compile-time literals. An attacker-controlled operator (e.g. from a generic `{field, op, value}` filter API) was therefore a **SQL-injection vector**:

```rust
.having("amount", ">= 0 UNION SELECT password FROM users --", 0)
// → HAVING "amount" >= 0 UNION SELECT password FROM users -- $1
```

## Change

Validate `op` case-insensitively against a fixed allowlist (`=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `LIKE`, `NOT LIKE`); anything else **panics** (fail-loud, matching the existing `offset`/`distinct_on`/lock guards). Use `having_raw()` for arbitrary aggregate expressions.

**Non-breaking:** every existing call using a standard comparison operator keeps working unchanged (the two existing `having` call sites in `tests/join.rs` use `">"`).

## Tests

New `tests/having_guard.rs` (4): allowed operators compile, case-insensitive + trimmed, and two injection attempts that must panic (`#[should_panic]`). Full suite green; `cargo fmt --check` + `cargo publish --dry-run` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)