### PR TITLE
feat!: fallible compilation — BuildError/Error, try_* API (3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Fallible compilation: `BuildError` + the `try_*` family.** Every fail-loud
+  guard that used to be reachable only as a panic now also surfaces as a typed
+  error, so web apps can map invalid query construction to an HTTP 4XX/5XX
+  response instead of crashing:
+  - New `BuildError` enum (`#[non_exhaustive]`, implements
+    `std::error::Error`): `LockRequiresSelect`, `DistinctOnRequiresPostgres`,
+    `EmptyInsert`, `EmptyUpdate`, `OffsetWithoutLimit`, `LockWithUnion`,
+    `InvalidHavingOperator(String)`.
+  - New fallible twins: `QueryBuilder::try_to_sql()`, `try_compile(&qb)`, and
+    (with a `sqlx_*` feature) `try_to_sqlx_query()` / `try_to_sqlx_query_as()`.
+  - The panicking API (`to_sql`, `compile`, `to_sqlx_query`,
+    `to_sqlx_query_as`) is unchanged and panics with exactly the `BuildError`
+    display message.
+  - New `SqlxQuery<'q, D>` / `SqlxQueryAs<'q, D, T>` type aliases for the sqlx
+    handoff types (re-exported at the crate root alongside `SqlxDialect`).
+  - **Policy:** the panicking API (`to_sql`, `compile`, `to_sqlx_query`,
+    `to_sqlx_query_as`) is kept *deliberately* alongside the `try_*` twins —
+    it stays the ergonomic path for static, hand-written queries (tests,
+    migrations, fixed reports), while the `try_*` family is the path for any
+    query shaped by runtime input. Both surfaces are maintained; the panicking
+    twins are not deprecated.
+
+### Changed
+
+- **BREAKING: the execution helpers (`fetch_all`/`fetch_one`/`fetch_optional`/
+  `execute`/`count`/`fetch_scalar`/`fetch_optional_scalar`) now return
+  `Result<_, chain_builder::Error>` instead of `Result<_, sqlx::Error>`.**
+  `Error` is a unified enum: `Error::Build(BuildError)` for invalid query
+  construction (returned **before** touching the database — previously a
+  panic) and `Error::Sqlx(sqlx::Error)` for database/driver failures. It
+  implements `std::error::Error` (with `source()`), `Display`, and
+  `From<BuildError>` / `From<sqlx::Error>`, so existing `?` call sites
+  migrate by switching the function's error type to `chain_builder::Error`
+  (or any type with `From<chain_builder::Error>`); match on `Error::Sqlx(e)`
+  to recover the inner sqlx error (e.g. `RowNotFound`).
+
+- **`having()` with a disallowed operator no longer panics at the call site.**
+  The error is recorded on the builder (first error wins, the chain stays
+  intact) and surfaces at compile time: `try_to_sql()` returns
+  `Err(BuildError::InvalidHavingOperator)`, `to_sql()` panics with the same
+  message as before — including when the offending builder is nested as a CTE,
+  UNION arm, or subquery. Code that called `having()` with a bad operator and
+  never compiled the builder previously panicked; it now does not.
+
 ## [2.1.2] - 2026-06-10
 
 ### Security

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -14,7 +14,9 @@ chain-builder = { version = "2", features = ["sqlx_postgres"] }
 
 `QueryBuilder::<D>::table(name)` starts a query for dialect `D`
 (`Postgres` / `MySql` / `Sqlite`). Every method is by-value chaining; `to_sql()`
-returns `(String, Vec<Value>)`.
+returns `(String, Vec<Value>)` and panics on an invalid builder, while
+`try_to_sql()` returns `Result<(String, Vec<Value>), BuildError>` (see
+[Error handling](#error-handling-try_to_sql--builderror)).
 
 ```rust
 use chain_builder::{QueryBuilder, Postgres, Order};
@@ -63,7 +65,7 @@ Empty `IN ()` → `1 = 0`; empty `NOT IN ()` → `1 = 1`.
 
 `select([cols])` (bare identifiers, dotted ok), `select_raw(expr, binds)` for
 arbitrary expressions, `distinct()`, `distinct_on([cols])` (Postgres only —
-panics elsewhere).
+errors elsewhere: `try_to_sql()` returns `Err`, `to_sql()` panics).
 
 Structured aggregate helpers escape the column at compile time (`*` passed
 through) and accept an optional alias via the `_as` variants:
@@ -162,8 +164,60 @@ let id: i64 = qb.fetch_scalar(&pool).await?;               // first column
 qb.execute(&pool).await?;                                   // INSERT/UPDATE/DELETE
 ```
 
+All execution helpers return `Result<_, chain_builder::Error>`:
+`Error::Build(BuildError)` for invalid query construction (returned before
+touching the database) and `Error::Sqlx(sqlx::Error)` for database failures.
+Both directions have `From` impls, so `?` works in functions whose error type
+converts from either.
+
 All three drivers can be enabled at once (`sqlx_mysql` + `sqlx_sqlite` +
 `sqlx_postgres`).
+
+## Error handling (`try_to_sql` / `BuildError`)
+
+Invalid query construction — `offset()` without `limit()`, an empty
+`insert()`/`update()`, a row lock outside `SELECT` or combined with `UNION`,
+`distinct_on` off Postgres, a disallowed `having()` operator — is a
+`BuildError`. The fallible API returns it; the classic API panics with the same
+message:
+
+| fallible (returns `Result<_, BuildError>`) | panicking twin |
+|---|---|
+| `try_to_sql()` | `to_sql()` |
+| `try_compile(&qb)` | `compile(&qb)` |
+| `try_to_sqlx_query()` | `to_sqlx_query()` |
+| `try_to_sqlx_query_as::<T>()` | `to_sqlx_query_as::<T>()` |
+
+The execution helpers (`fetch_*`, `execute`, `count`) fold both failure modes
+into the unified `Error` enum — `Error::Build(BuildError)` /
+`Error::Sqlx(sqlx::Error)` — so they never panic on an invalid builder.
+
+A disallowed `having()` operator does not panic at the call site — the chain
+stays intact and the error is deferred until compilation (also through nested
+builders: CTEs, UNION arms, subqueries). In a web handler, map `BuildError`
+variants caused by end-user input to HTTP 4XX and the rest to 5XX:
+
+```rust
+match qb.fetch_all::<Row, _>(&pool).await {
+    Ok(rows) => ok(rows),
+    Err(Error::Build(BuildError::InvalidHavingOperator(_))) => bad_request(), // 400
+    Err(Error::Build(e)) => internal_error(e),  // 500 — programmer error
+    Err(Error::Sqlx(e)) => internal_error(e),   // 500 — database failure
+    // `Error` is #[non_exhaustive]: downstream matches need a wildcard arm.
+    Err(e) => internal_error(e),
+}
+```
+
+Both `Error` and `BuildError` are `#[non_exhaustive]` — when matching outside
+this crate, always include a wildcard arm so future variants don't break your
+build.
+
+The panicking API (`to_sql()`, `compile()`, `to_sqlx_query[_as]()`) is kept
+**deliberately** alongside the `try_*` twins: it is the ergonomic choice for
+static, hand-written queries (tests, migrations, fixed reports) where invalid
+construction is a programmer error and a panic message is the fastest signal.
+Use the `try_*` family whenever any part of the query is driven by runtime
+input.
 
 ## Raw escape hatches
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,8 +6,9 @@
 
 use core::marker::PhantomData;
 
-use crate::compile::compile;
+use crate::compile::{compile, try_compile};
 use crate::dialect::Dialect;
+use crate::error::BuildError;
 use crate::value::{IntoBind, Value};
 use crate::where_::{Conj, Predicate, WhereBuilder};
 
@@ -323,6 +324,10 @@ pub struct QueryBuilder<D: Dialect> {
     pub(crate) returning: Vec<String>,
     /// Row-locking clause (`FOR UPDATE`/`FOR SHARE`); SELECT-only, no-op on SQLite.
     pub(crate) lock: Option<Lock>,
+    /// First misuse detected by a builder method (e.g. a disallowed `having()`
+    /// operator). Deferred instead of panicking mid-chain; surfaced by
+    /// [`Self::try_to_sql`] as `Err` (and by [`Self::to_sql`] as a panic).
+    pub(crate) error: Option<BuildError>,
     _marker: PhantomData<D>,
 }
 
@@ -355,6 +360,7 @@ impl<D: Dialect> QueryBuilder<D> {
             on_conflict: None,
             returning: Vec::new(),
             lock: None,
+            error: None,
             _marker: PhantomData,
         }
     }
@@ -1042,11 +1048,14 @@ impl<D: Dialect> QueryBuilder<D> {
     /// **verbatim** into the SQL (it is not a bound value and cannot be escaped
     /// without changing its meaning), an attacker-controlled operator would be a
     /// SQL-injection vector. To prevent that, `op` is validated against a fixed
-    /// set of comparison operators and a disallowed operator **panics**
-    /// (fail-loud, like the `offset`/`distinct_on`/lock guards). The operator is
-    /// matched case-insensitively and stored trimmed. For anything outside this
-    /// set — arbitrary aggregate expressions, custom operators — use
-    /// [`Self::having_raw`], the documented verbatim escape hatch.
+    /// set of comparison operators. A disallowed operator records a deferred
+    /// [`BuildError::InvalidHavingOperator`] (the chain stays intact):
+    /// [`Self::try_to_sql`] returns it as `Err`, while [`Self::to_sql`] panics
+    /// with the same message (fail-loud, like the `offset`/`distinct_on`/lock
+    /// guards). The operator is matched case-insensitively and stored trimmed.
+    /// For anything outside this set — arbitrary aggregate expressions, custom
+    /// operators — use [`Self::having_raw`], the documented verbatim escape
+    /// hatch.
     ///
     /// Allowed: `=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `LIKE`, `NOT LIKE`.
     pub fn having(mut self, col: &str, op: &str, val: impl IntoBind) -> Self {
@@ -1057,10 +1066,12 @@ impl<D: Dialect> QueryBuilder<D> {
             .iter()
             .any(|allowed| allowed.eq_ignore_ascii_case(normalized))
         {
-            panic!(
-                "having() operator {op:?} is not an allowed comparison operator \
-                 (use having_raw() for arbitrary aggregate expressions)"
-            );
+            // Keep the FIRST error: it points at the original misuse, and a
+            // later mistake must not mask it.
+            if self.error.is_none() {
+                self.error = Some(BuildError::InvalidHavingOperator(op.to_owned()));
+            }
+            return self;
         }
         self.havings.push(Having::Col {
             col: col.to_owned(),
@@ -1132,15 +1143,13 @@ impl<D: Dialect> QueryBuilder<D> {
     /// by-value chain.
     ///
     /// ```
-    /// # #[cfg(feature = "v2")] {
-    /// use chain_builder::v2::{Postgres, QueryBuilder};
+    /// use chain_builder::{Postgres, QueryBuilder};
     /// let only_active = true;
     /// let (sql, _) = QueryBuilder::<Postgres>::table("users")
     ///     .select(["id"])
     ///     .when(only_active, |q| q.where_eq("status", "active"))
     ///     .to_sql();
     /// assert_eq!(sql, r#"SELECT "id" FROM "users" WHERE "status" = $1"#);
-    /// # }
     /// ```
     pub fn when(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self {
         if cond {
@@ -1154,8 +1163,7 @@ impl<D: Dialect> QueryBuilder<D> {
     /// chain intact.
     ///
     /// ```
-    /// # #[cfg(feature = "v2")] {
-    /// use chain_builder::v2::{Postgres, QueryBuilder};
+    /// use chain_builder::{Postgres, QueryBuilder};
     /// let active = false;
     /// let (sql, _) = QueryBuilder::<Postgres>::table("users")
     ///     .select(["id"])
@@ -1166,7 +1174,6 @@ impl<D: Dialect> QueryBuilder<D> {
     ///     )
     ///     .to_sql();
     /// assert_eq!(sql, r#"SELECT "id" FROM "users" WHERE "status" = $1"#);
-    /// # }
     /// ```
     pub fn when_else(
         self,
@@ -1189,22 +1196,37 @@ impl<D: Dialect> QueryBuilder<D> {
     /// negative offset. SELECT-only, like [`Self::limit`] / [`Self::offset`].
     ///
     /// ```
-    /// # #[cfg(feature = "v2")] {
-    /// use chain_builder::v2::{Postgres, QueryBuilder, Value};
+    /// use chain_builder::{Postgres, QueryBuilder, Value};
     /// let (sql, binds) = QueryBuilder::<Postgres>::table("users")
     ///     .select(["id"])
     ///     .paginate(2, 10)
     ///     .to_sql();
     /// assert_eq!(sql, r#"SELECT "id" FROM "users" LIMIT $1 OFFSET $2"#);
     /// assert_eq!(binds, vec![Value::I64(10), Value::I64(10)]);
-    /// # }
     /// ```
     pub fn paginate(self, page: i64, per_page: i64) -> Self {
         self.limit(per_page).offset((page - 1).max(0) * per_page)
     }
 
-    /// Compile to `(sql, binds)`.
+    /// Compile to `(sql, binds)`, panicking on an invalid builder.
+    ///
+    /// Panicking twin of [`Self::try_to_sql`]; the panic message is the
+    /// [`BuildError`]'s `Display` text. Prefer [`Self::try_to_sql`] when any
+    /// part of the query is driven by runtime input (e.g. an HTTP request), so
+    /// misuse maps to an error response instead of a crash.
     pub fn to_sql(&self) -> (String, Vec<Value>) {
         compile(self)
+    }
+
+    /// Compile to `(sql, binds)`, or return the [`BuildError`] describing why
+    /// the query cannot be rendered (invalid construction such as `offset()`
+    /// without `limit()`, an empty `insert()`/`update()`, a row lock outside
+    /// SELECT, or a disallowed `having()` operator).
+    ///
+    /// Errors recorded by builder methods (deferred, chain-preserving) and
+    /// errors detected during compilation — including inside nested builders
+    /// (CTEs, UNION arms, subqueries) — all surface here.
+    pub fn try_to_sql(&self) -> Result<(String, Vec<Value>), BuildError> {
+        try_compile(self)
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -10,6 +10,7 @@ use crate::builder::{
     Order, QueryBuilder, SelectExpr,
 };
 use crate::dialect::{Dialect, UpsertStyle};
+use crate::error::BuildError;
 use crate::ident::escape_identifier;
 use crate::value::Value;
 use crate::where_::{Conj, Predicate};
@@ -54,21 +55,40 @@ impl Ctx {
     }
 }
 
-/// Compile a [`QueryBuilder`] into `(sql, binds)`.
+/// Compile a [`QueryBuilder`] into `(sql, binds)`, panicking on an invalid
+/// builder.
+///
+/// Panicking wrapper over [`try_compile`]; the panic message is the
+/// [`BuildError`]'s `Display` text. Prefer [`try_compile`] /
+/// [`QueryBuilder::try_to_sql`](crate::QueryBuilder::try_to_sql) when the
+/// builder may be fed from runtime input (e.g. an HTTP request).
 pub fn compile<D: Dialect>(qb: &QueryBuilder<D>) -> (String, Vec<Value>) {
+    try_compile(qb).unwrap_or_else(|e| panic!("{e}"))
+}
+
+/// Compile a [`QueryBuilder`] into `(sql, binds)`, or return the
+/// [`BuildError`] describing why the query cannot be rendered.
+pub fn try_compile<D: Dialect>(qb: &QueryBuilder<D>) -> Result<(String, Vec<Value>), BuildError> {
     let mut ctx = Ctx {
         sql: String::new(),
         binds: Vec::new(),
         quote: D::quote_char(),
     };
-    compile_into::<D>(&mut ctx, qb);
-    (ctx.sql, ctx.binds)
+    compile_into::<D>(&mut ctx, qb)?;
+    Ok((ctx.sql, ctx.binds))
 }
 
 /// Write `qb`'s SQL into the existing `ctx`, continuing its binds and
 /// placeholder counter. This is the single-pass core used by [`compile`] (and,
 /// in later M2 tasks, by nested builders such as CTEs/UNION arms).
-fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
+fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) -> Result<(), BuildError> {
+    // A builder method that detected misuse (e.g. `having()` with a disallowed
+    // operator) records the first error instead of panicking mid-chain; it
+    // surfaces here. Checked per nested builder too (CTE/UNION/subquery).
+    if let Some(e) = &qb.error {
+        return Err(e.clone());
+    }
+
     let table = ctx.qualify(qb.db.as_deref(), &qb.table);
 
     // A row lock is only meaningful on SELECT. Attaching one to INSERT/UPDATE/
@@ -76,16 +96,16 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
     // (the caller believes rows are locked when they are not). Fail loud,
     // dialect-independent, like the `offset`/`distinct_on` guards.
     if qb.lock.is_some() && qb.method != Method::Select {
-        panic!("for_update()/for_share() is only valid on SELECT");
+        return Err(BuildError::LockRequiresSelect);
     }
 
     match qb.method {
         Method::Select => {
             // CTEs are emitted first so their binds (and pg `$N`) come first.
-            write_ctes::<D>(ctx, &qb.ctes);
+            write_ctes::<D>(ctx, &qb.ctes)?;
             if !qb.distinct_on.is_empty() {
                 if !D::supports_distinct_on() {
-                    panic!("DISTINCT ON requires PostgreSQL");
+                    return Err(BuildError::DistinctOnRequiresPostgres);
                 }
                 ctx.sql.push_str("SELECT DISTINCT ON (");
                 let cols: Vec<String> = qb.distinct_on.iter().map(|c| ctx.esc(c)).collect();
@@ -96,21 +116,21 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             } else {
                 ctx.sql.push_str("SELECT ");
             }
-            write_select_list::<D>(ctx, qb);
+            write_select_list::<D>(ctx, qb)?;
             ctx.sql.push_str(" FROM ");
             ctx.sql.push_str(&table);
             write_joins::<D>(ctx, &qb.joins, qb.db.as_deref());
-            write_wheres::<D>(ctx, &qb.wheres);
+            write_wheres::<D>(ctx, &qb.wheres)?;
             write_group_by(ctx, &qb.groups, qb.group_by_raw.as_ref());
             write_having::<D>(ctx, &qb.havings);
             write_order_by(ctx, &qb.orders, qb.order_by_raw.as_ref());
-            write_limit_offset::<D>(ctx, qb.limit, qb.offset);
-            write_unions::<D>(ctx, &qb.unions);
-            write_lock::<D>(ctx, qb.lock.as_ref(), !qb.unions.is_empty());
+            write_limit_offset::<D>(ctx, qb.limit, qb.offset)?;
+            write_unions::<D>(ctx, &qb.unions)?;
+            write_lock::<D>(ctx, qb.lock.as_ref(), !qb.unions.is_empty())?;
         }
         Method::Insert => {
             if qb.set.is_empty() && qb.insert_rows.is_empty() {
-                panic!("insert() requires at least one column");
+                return Err(BuildError::EmptyInsert);
             }
 
             // Single-row sorted pairs (preserves the M-prev path byte-for-byte,
@@ -188,7 +208,7 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
         }
         Method::Update => {
             if qb.set.is_empty() {
-                panic!("update() requires at least one column");
+                return Err(BuildError::EmptyUpdate);
             }
             let mut rows: Vec<&(String, Value)> = qb.set.iter().collect();
             rows.sort_by(|a, b| a.0.cmp(&b.0));
@@ -204,16 +224,17 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
                 ctx.sql.push_str(" = ");
                 ctx.placeholder::<D>(v.clone());
             }
-            write_wheres::<D>(ctx, &qb.wheres);
+            write_wheres::<D>(ctx, &qb.wheres)?;
             write_returning::<D>(ctx, &qb.returning);
         }
         Method::Delete => {
             ctx.sql.push_str("DELETE FROM ");
             ctx.sql.push_str(&table);
-            write_wheres::<D>(ctx, &qb.wheres);
+            write_wheres::<D>(ctx, &qb.wheres)?;
             write_returning::<D>(ctx, &qb.returning);
         }
     }
+    Ok(())
 }
 
 /// Render the upsert conflict clause for an `INSERT` (never called for the
@@ -315,14 +336,14 @@ fn write_group_by(ctx: &mut Ctx, groups: &[String], raw: Option<&(String, Vec<Va
 ///
 /// Written directly into `ctx` (not pre-joined) so subquery binds continue the
 /// placeholder counter in emission order.
-fn write_select_list<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
+fn write_select_list<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) -> Result<(), BuildError> {
     if qb.select_cols.is_empty()
         && qb.select_exprs.is_empty()
         && qb.select_raw.is_empty()
         && qb.select_subqueries.is_empty()
     {
         ctx.sql.push('*');
-        return;
+        return Ok(());
     }
     let mut wrote_any = false;
     for c in &qb.select_cols {
@@ -379,12 +400,13 @@ fn write_select_list<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) {
             ctx.sql.push_str(", ");
         }
         ctx.sql.push('(');
-        compile_into::<D>(ctx, sub);
+        compile_into::<D>(ctx, sub)?;
         ctx.sql.push_str(") AS ");
         let a = ctx.esc(alias);
         ctx.sql.push_str(&a);
         wrote_any = true;
     }
+    Ok(())
 }
 
 /// Render each `JOIN` (SELECT only): ` {KIND} {esc table}[ ON cond AND …]`.
@@ -470,9 +492,9 @@ fn write_having<D: Dialect>(ctx: &mut Ctx, havings: &[Having]) {
 ///
 /// Single-pass per CTE: the name header is written and the body compiled in one
 /// go, so SQL text order equals bind-push order (placeholder/bind never desync).
-fn write_ctes<D: Dialect>(ctx: &mut Ctx, ctes: &[Cte<D>]) {
+fn write_ctes<D: Dialect>(ctx: &mut Ctx, ctes: &[Cte<D>]) -> Result<(), BuildError> {
     if ctes.is_empty() {
-        return;
+        return Ok(());
     }
     ctx.sql.push_str("WITH ");
     if ctes.iter().any(|c| c.recursive) {
@@ -485,19 +507,24 @@ fn write_ctes<D: Dialect>(ctx: &mut Ctx, ctes: &[Cte<D>]) {
         let name = ctx.esc(&cte.name);
         ctx.sql.push_str(&name);
         ctx.sql.push_str(" AS (");
-        compile_into::<D>(ctx, &cte.query);
+        compile_into::<D>(ctx, &cte.query)?;
         ctx.sql.push(')');
     }
     ctx.sql.push(' ');
+    Ok(())
 }
 
 /// Render ` UNION [ALL] body` per arm, AFTER the main query (SELECT only).
-fn write_unions<D: Dialect>(ctx: &mut Ctx, unions: &[(bool, QueryBuilder<D>)]) {
+fn write_unions<D: Dialect>(
+    ctx: &mut Ctx,
+    unions: &[(bool, QueryBuilder<D>)],
+) -> Result<(), BuildError> {
     for (all, arm) in unions {
         ctx.sql
             .push_str(if *all { " UNION ALL " } else { " UNION " });
-        compile_into::<D>(ctx, arm);
+        compile_into::<D>(ctx, arm)?;
     }
+    Ok(())
 }
 
 /// Render `ORDER BY a ASC, b DESC, …` (SELECT only). No-op when empty and no raw
@@ -531,11 +558,15 @@ fn write_order_by(ctx: &mut Ctx, orders: &[(String, Order)], raw: Option<&(Strin
 
 /// Render `LIMIT $n [OFFSET $m]` (SELECT only), binding both values.
 ///
-/// Panics if `offset` is set without `limit` (uniform across dialects; MySQL
+/// Errors if `offset` is set without `limit` (uniform across dialects; MySQL
 /// rejects bare `OFFSET`).
-fn write_limit_offset<D: Dialect>(ctx: &mut Ctx, limit: Option<i64>, offset: Option<i64>) {
+fn write_limit_offset<D: Dialect>(
+    ctx: &mut Ctx,
+    limit: Option<i64>,
+    offset: Option<i64>,
+) -> Result<(), BuildError> {
     if offset.is_some() && limit.is_none() {
-        panic!("offset(...) requires limit(...)");
+        return Err(BuildError::OffsetWithoutLimit);
     }
     if let Some(n) = limit {
         ctx.sql.push_str(" LIMIT ");
@@ -545,25 +576,30 @@ fn write_limit_offset<D: Dialect>(ctx: &mut Ctx, limit: Option<i64>, offset: Opt
         ctx.sql.push_str(" OFFSET ");
         ctx.placeholder::<D>(Value::I64(n));
     }
+    Ok(())
 }
 
 /// Render a row-locking clause (` FOR UPDATE`/` FOR SHARE` [+ ` SKIP LOCKED`/
 /// ` NOWAIT`]) at the end of a `SELECT`. A **no-op on dialects without row
 /// locking** (SQLite), so the lock is silently dropped there rather than
-/// producing invalid SQL. Panics if a lock is combined with `UNION` on a
+/// producing invalid SQL. Errors if a lock is combined with `UNION` on a
 /// locking dialect (Postgres/MySQL reject that combination).
-fn write_lock<D: Dialect>(ctx: &mut Ctx, lock: Option<&Lock>, has_unions: bool) {
+fn write_lock<D: Dialect>(
+    ctx: &mut Ctx,
+    lock: Option<&Lock>,
+    has_unions: bool,
+) -> Result<(), BuildError> {
     let Some(lock) = lock else {
-        return;
+        return Ok(());
     };
     if !D::supports_row_locking() {
-        return;
+        return Ok(());
     }
     // Postgres/MySQL reject `FOR UPDATE`/`FOR SHARE` on a `UNION` result; emitting
     // it would produce invalid SQL, so fail loud here. (No-op dialects returned
     // above never reach this, so a SQLite lock+UNION stays a harmless no-op.)
     if has_unions {
-        panic!("for_update()/for_share() cannot be combined with UNION");
+        return Err(BuildError::LockWithUnion);
     }
     ctx.sql.push_str(match lock.strength {
         LockStrength::Update => " FOR UPDATE",
@@ -575,6 +611,7 @@ fn write_lock<D: Dialect>(ctx: &mut Ctx, lock: Option<&Lock>, has_unions: bool) 
             LockWait::NoWait => " NOWAIT",
         });
     }
+    Ok(())
 }
 
 /// A predicate produces no SQL if it is an empty group (F4): an empty group
@@ -584,20 +621,20 @@ fn is_omitted<D: Dialect>(p: &Predicate<D>) -> bool {
     matches!(p, Predicate::Group { preds, .. } if preds.is_empty())
 }
 
-fn write_wheres<D: Dialect>(ctx: &mut Ctx, wheres: &[Predicate<D>]) {
+fn write_wheres<D: Dialect>(ctx: &mut Ctx, wheres: &[Predicate<D>]) -> Result<(), BuildError> {
     // Skip empty groups so they neither emit `()` nor force a `WHERE`.
     if wheres.iter().all(is_omitted) {
-        return;
+        return Ok(());
     }
     ctx.sql.push_str(" WHERE ");
-    write_clause_list::<D>(ctx, wheres);
+    write_clause_list::<D>(ctx, wheres)
 }
 
 /// Render a top-level clause list. Predicates are joined by `AND` by default,
 /// but a [`Predicate::Group`] attaches to the preceding clause using its own
 /// outer conjunction (so `or_where` emits `... OR (...)`). Empty groups are
 /// omitted and never contribute a separator.
-fn write_clause_list<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate<D>]) {
+fn write_clause_list<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate<D>]) -> Result<(), BuildError> {
     let mut wrote_any = false;
     for p in preds.iter() {
         if is_omitted(p) {
@@ -613,12 +650,13 @@ fn write_clause_list<D: Dialect>(ctx: &mut Ctx, preds: &[Predicate<D>]) {
             };
             ctx.sql.push_str(sep);
         }
-        write_pred::<D>(ctx, p);
+        write_pred::<D>(ctx, p)?;
         wrote_any = true;
     }
+    Ok(())
 }
 
-fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate<D>) {
+fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate<D>) -> Result<(), BuildError> {
     match pred {
         Predicate::Binary { col, op, val } => {
             let col = ctx.esc(col);
@@ -632,7 +670,7 @@ fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate<D>) {
             if vals.is_empty() {
                 // Empty IN is always false; empty NOT IN is always true.
                 ctx.sql.push_str(if *neg { "1 = 1" } else { "1 = 0" });
-                return;
+                return Ok(());
             }
             let col = ctx.esc(col);
             ctx.sql.push_str(&col);
@@ -705,7 +743,7 @@ fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate<D>) {
             // `write_wheres` filter them via `is_omitted` (F4), so we never
             // emit invalid `()`.
             ctx.sql.push('(');
-            write_clause_list::<D>(ctx, preds);
+            write_clause_list::<D>(ctx, preds)?;
             ctx.sql.push(')');
         }
         Predicate::Column { lhs, op, rhs } => {
@@ -720,15 +758,16 @@ fn write_pred<D: Dialect>(ctx: &mut Ctx, pred: &Predicate<D>) {
         Predicate::Exists { neg, sub } => {
             ctx.sql
                 .push_str(if *neg { "NOT EXISTS (" } else { "EXISTS (" });
-            compile_into::<D>(ctx, sub);
+            compile_into::<D>(ctx, sub)?;
             ctx.sql.push(')');
         }
         Predicate::InSubquery { col, neg, sub } => {
             let col = ctx.esc(col);
             ctx.sql.push_str(&col);
             ctx.sql.push_str(if *neg { " NOT IN (" } else { " IN (" });
-            compile_into::<D>(ctx, sub);
+            compile_into::<D>(ctx, sub)?;
             ctx.sql.push(')');
         }
     }
+    Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,123 @@
+//! Typed errors for fallible compilation ([`QueryBuilder::try_to_sql`]).
+//!
+//! Every fail-loud guard in the compiler maps to one [`BuildError`] variant.
+//! [`QueryBuilder::to_sql`] panics with exactly the [`Display`] message of the
+//! corresponding variant, so the panicking and fallible paths stay in sync.
+//!
+//! [`QueryBuilder::try_to_sql`]: crate::QueryBuilder::try_to_sql
+//! [`QueryBuilder::to_sql`]: crate::QueryBuilder::to_sql
+//! [`Display`]: core::fmt::Display
+
+use core::fmt;
+
+/// Invalid query construction, detected when compiling a
+/// [`QueryBuilder`](crate::QueryBuilder).
+///
+/// Returned by [`try_to_sql`](crate::QueryBuilder::try_to_sql) /
+/// [`try_compile`](crate::try_compile) (and the sqlx handoff twins
+/// `try_to_sqlx_query` / `try_to_sqlx_query_as`). The panicking
+/// [`to_sql`](crate::QueryBuilder::to_sql) path panics with this type's
+/// [`Display`](core::fmt::Display) message.
+///
+/// All variants describe *caller* mistakes (a query that cannot be rendered as
+/// valid SQL), never internal compiler state — a web app can therefore map
+/// errors caused by end-user input (e.g. an operator or pagination parameter
+/// taken from a request) to HTTP 4XX and the rest to 5XX.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BuildError {
+    /// `for_update()`/`for_share()` on a non-SELECT query.
+    LockRequiresSelect,
+    /// `distinct_on(...)` compiled for a dialect without `DISTINCT ON`.
+    DistinctOnRequiresPostgres,
+    /// `insert()` with no columns.
+    EmptyInsert,
+    /// `update()` with no columns.
+    EmptyUpdate,
+    /// `offset(...)` without `limit(...)`.
+    OffsetWithoutLimit,
+    /// `for_update()`/`for_share()` combined with `UNION`.
+    LockWithUnion,
+    /// `having()` received an operator outside the fixed allowlist. Carries the
+    /// rejected operator as passed by the caller.
+    InvalidHavingOperator(String),
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LockRequiresSelect => {
+                f.write_str("for_update()/for_share() is only valid on SELECT")
+            }
+            Self::DistinctOnRequiresPostgres => f.write_str("DISTINCT ON requires PostgreSQL"),
+            Self::EmptyInsert => f.write_str("insert() requires at least one column"),
+            Self::EmptyUpdate => f.write_str("update() requires at least one column"),
+            Self::OffsetWithoutLimit => f.write_str("offset(...) requires limit(...)"),
+            Self::LockWithUnion => {
+                f.write_str("for_update()/for_share() cannot be combined with UNION")
+            }
+            Self::InvalidHavingOperator(op) => write!(
+                f,
+                "having() operator {op:?} is not an allowed comparison operator \
+                 (use having_raw() for arbitrary aggregate expressions)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BuildError {}
+
+/// Unified error for the execution helpers (`fetch_*`, `execute`, `count`):
+/// the query either failed to **build** (invalid construction, see
+/// [`BuildError`]) or failed to **execute** (database/driver error from sqlx).
+///
+/// `From` impls for both sides make `?` work directly in handlers, and
+/// matching on the variant separates caller mistakes (often HTTP 4XX when the
+/// offending input came from a request) from runtime database failures (5XX):
+///
+/// ```ignore
+/// match qb.fetch_all::<Row, _>(&pool).await {
+///     Ok(rows) => ...,
+///     Err(Error::Build(e)) => ...,  // invalid query construction
+///     Err(Error::Sqlx(e)) => ...,   // connection/query/decode failure
+///     Err(e) => ...,                // #[non_exhaustive]: wildcard required downstream
+/// }
+/// ```
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// The builder could not be compiled into SQL.
+    Build(BuildError),
+    /// sqlx failed to execute the compiled query.
+    Sqlx(sqlx::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Build(e) => e.fmt(f),
+            Self::Sqlx(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Build(e) => Some(e),
+            Self::Sqlx(e) => Some(e),
+        }
+    }
+}
+
+impl From<BuildError> for Error {
+    fn from(e: BuildError) -> Self {
+        Self::Build(e)
+    }
+}
+
+impl From<sqlx::Error> for Error {
+    fn from(e: sqlx::Error) -> Self {
+        Self::Sqlx(e)
+    }
+}

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,63 +1,78 @@
 //! Typed fetch / execution helpers for v2 (`feature = "sqlx_*"`).
 //!
 //! These are thin async delegations on top of the sqlx query objects already
-//! produced by [`to_sqlx_query`](QueryBuilder::to_sqlx_query) and
-//! [`to_sqlx_query_as`](QueryBuilder::to_sqlx_query_as) in
+//! produced by [`try_to_sqlx_query`](QueryBuilder::try_to_sqlx_query) and
+//! [`try_to_sqlx_query_as`](QueryBuilder::try_to_sqlx_query_as) in
 //! [`crate::sqlx_bind`]. They let any [`QueryBuilder<D>`] whose
 //! `D: SqlxDialect` run against a sqlx [`Executor`](sqlx::Executor) and decode
 //! rows into a `T: FromRow`, or pull a single scalar column.
+//!
+//! Every helper returns the unified [`Error`]: an invalid builder surfaces as
+//! [`Error::Build`] **before** touching the database, and a database/driver
+//! failure surfaces as [`Error::Sqlx`] — never a panic.
 //!
 //! [`count`](QueryBuilder::count) mirrors 1.x `ChainBuilder::count`: it wraps the
 //! built SQL in `SELECT COUNT(*) FROM (<sql>) AS __cb_count`, binds the same
 //! arguments, and fetches a single `i64`.
 
 use crate::builder::QueryBuilder;
+use crate::error::Error;
 use crate::sqlx_bind::SqlxDialect;
 
 impl<D: SqlxDialect> QueryBuilder<D> {
     /// Fetch all rows, decoding each into `T`.
     ///
-    /// Delegates to `self.to_sqlx_query_as::<T>().fetch_all(executor)`.
-    pub async fn fetch_all<'e, T, E>(&self, executor: E) -> Result<Vec<T>, sqlx::Error>
+    /// Delegates to `self.try_to_sqlx_query_as::<T>()?.fetch_all(executor)`.
+    pub async fn fetch_all<'e, T, E>(&self, executor: E) -> Result<Vec<T>, Error>
     where
         T: for<'r> sqlx::FromRow<'r, <D::Database as sqlx::Database>::Row> + Send + Unpin,
         E: sqlx::Executor<'e, Database = D::Database>,
     {
-        self.to_sqlx_query_as::<T>().fetch_all(executor).await
+        Ok(self
+            .try_to_sqlx_query_as::<T>()?
+            .fetch_all(executor)
+            .await?)
     }
 
     /// Fetch exactly one row, decoding it into `T`.
     ///
-    /// Errors with [`sqlx::Error::RowNotFound`] if no row is returned.
-    pub async fn fetch_one<'e, T, E>(&self, executor: E) -> Result<T, sqlx::Error>
+    /// Errors with [`sqlx::Error::RowNotFound`] (as [`Error::Sqlx`]) if no row
+    /// is returned.
+    pub async fn fetch_one<'e, T, E>(&self, executor: E) -> Result<T, Error>
     where
         T: for<'r> sqlx::FromRow<'r, <D::Database as sqlx::Database>::Row> + Send + Unpin,
         E: sqlx::Executor<'e, Database = D::Database>,
     {
-        self.to_sqlx_query_as::<T>().fetch_one(executor).await
+        Ok(self
+            .try_to_sqlx_query_as::<T>()?
+            .fetch_one(executor)
+            .await?)
     }
 
     /// Fetch at most one row, decoding it into `T`.
-    pub async fn fetch_optional<'e, T, E>(&self, executor: E) -> Result<Option<T>, sqlx::Error>
+    pub async fn fetch_optional<'e, T, E>(&self, executor: E) -> Result<Option<T>, Error>
     where
         T: for<'r> sqlx::FromRow<'r, <D::Database as sqlx::Database>::Row> + Send + Unpin,
         E: sqlx::Executor<'e, Database = D::Database>,
     {
-        self.to_sqlx_query_as::<T>().fetch_optional(executor).await
+        Ok(self
+            .try_to_sqlx_query_as::<T>()?
+            .fetch_optional(executor)
+            .await?)
     }
 
     /// Execute the query (INSERT / UPDATE / DELETE / DDL), returning the
     /// database's `QueryResult` (affected rows, last insert id, …).
     ///
-    /// Delegates to `self.to_sqlx_query().execute(executor)`.
+    /// Delegates to `self.try_to_sqlx_query()?.execute(executor)`.
     pub async fn execute<'e, E>(
         &self,
         executor: E,
-    ) -> Result<<D::Database as sqlx::Database>::QueryResult, sqlx::Error>
+    ) -> Result<<D::Database as sqlx::Database>::QueryResult, Error>
     where
         E: sqlx::Executor<'e, Database = D::Database>,
     {
-        self.to_sqlx_query().execute(executor).await
+        Ok(self.try_to_sqlx_query()?.execute(executor).await?)
     }
 
     /// Count the rows the query would return.
@@ -65,7 +80,7 @@ impl<D: SqlxDialect> QueryBuilder<D> {
     /// Wraps the built SQL as `SELECT COUNT(*) FROM (<sql>) AS __cb_count`, binds
     /// the same arguments, and fetches a single `i64`. Mirrors 1.x
     /// `ChainBuilder::count`.
-    pub async fn count<'e, E>(&self, executor: E) -> Result<i64, sqlx::Error>
+    pub async fn count<'e, E>(&self, executor: E) -> Result<i64, Error>
     where
         E: sqlx::Executor<'e, Database = D::Database>,
         // `query_scalar_with` decodes `(i64,)` from the row, which needs `i64` to
@@ -74,19 +89,21 @@ impl<D: SqlxDialect> QueryBuilder<D> {
         i64: for<'r> sqlx::Decode<'r, D::Database> + sqlx::Type<D::Database>,
         usize: sqlx::ColumnIndex<<D::Database as sqlx::Database>::Row>,
     {
-        let (sql, binds) = self.to_sql();
+        let (sql, binds) = self.try_to_sql()?;
         let wrapped = format!("SELECT COUNT(*) FROM ({sql}) AS __cb_count");
         let args = D::bind_arguments(&binds);
-        sqlx::query_scalar_with::<D::Database, i64, _>(sqlx::AssertSqlSafe(wrapped), args)
-            .fetch_one(executor)
-            .await
+        Ok(
+            sqlx::query_scalar_with::<D::Database, i64, _>(sqlx::AssertSqlSafe(wrapped), args)
+                .fetch_one(executor)
+                .await?,
+        )
     }
 
     /// Fetch the first column of the first row, decoded into `T`.
     ///
-    /// Errors with [`sqlx::Error::RowNotFound`] if no row is returned. Useful for
-    /// `pluck`/aggregate-style queries.
-    pub async fn fetch_scalar<'e, T, E>(&self, executor: E) -> Result<T, sqlx::Error>
+    /// Errors with [`sqlx::Error::RowNotFound`] (as [`Error::Sqlx`]) if no row
+    /// is returned. Useful for `pluck`/aggregate-style queries.
+    pub async fn fetch_scalar<'e, T, E>(&self, executor: E) -> Result<T, Error>
     where
         T: for<'r> sqlx::Decode<'r, D::Database> + sqlx::Type<D::Database> + Send + Unpin,
         E: sqlx::Executor<'e, Database = D::Database>,
@@ -94,27 +111,28 @@ impl<D: SqlxDialect> QueryBuilder<D> {
         // index on the backend's row type.
         usize: sqlx::ColumnIndex<<D::Database as sqlx::Database>::Row>,
     {
-        let (sql, binds) = self.to_sql();
+        let (sql, binds) = self.try_to_sql()?;
         let args = D::bind_arguments(&binds);
-        sqlx::query_scalar_with::<D::Database, T, _>(sqlx::AssertSqlSafe(sql), args)
-            .fetch_one(executor)
-            .await
+        Ok(
+            sqlx::query_scalar_with::<D::Database, T, _>(sqlx::AssertSqlSafe(sql), args)
+                .fetch_one(executor)
+                .await?,
+        )
     }
 
     /// Fetch the first column of the first row (if any), decoded into `T`.
-    pub async fn fetch_optional_scalar<'e, T, E>(
-        &self,
-        executor: E,
-    ) -> Result<Option<T>, sqlx::Error>
+    pub async fn fetch_optional_scalar<'e, T, E>(&self, executor: E) -> Result<Option<T>, Error>
     where
         T: for<'r> sqlx::Decode<'r, D::Database> + sqlx::Type<D::Database> + Send + Unpin,
         E: sqlx::Executor<'e, Database = D::Database>,
         usize: sqlx::ColumnIndex<<D::Database as sqlx::Database>::Row>,
     {
-        let (sql, binds) = self.to_sql();
+        let (sql, binds) = self.try_to_sql()?;
         let args = D::bind_arguments(&binds);
-        sqlx::query_scalar_with::<D::Database, T, _>(sqlx::AssertSqlSafe(sql), args)
-            .fetch_optional(executor)
-            .await
+        Ok(
+            sqlx::query_scalar_with::<D::Database, T, _>(sqlx::AssertSqlSafe(sql), args)
+                .fetch_optional(executor)
+                .await?,
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 pub mod builder;
 pub mod compile;
 pub mod dialect;
+pub mod error;
 pub mod ident;
 pub mod value;
 pub mod where_;
@@ -51,8 +52,9 @@ pub use builder::{
     AggFn, ConflictAction, Cte, Having, Join, JoinClause, JoinCond, JoinKind, Lock, LockStrength,
     LockWait, Method, OnConflict, Order, QueryBuilder, SelectExpr,
 };
-pub use compile::compile;
+pub use compile::{compile, try_compile};
 pub use dialect::{Dialect, MySql, Postgres, Sqlite, UpsertStyle};
+pub use error::{BuildError, Error};
 pub use value::{IntoBind, Value};
 pub use where_::{Conj, Predicate, WhereBuilder};
 
@@ -61,4 +63,4 @@ pub use where_::{Conj, Predicate, WhereBuilder};
     feature = "sqlx_sqlite",
     feature = "sqlx_postgres"
 ))]
-pub use sqlx_bind::SqlxDialect;
+pub use sqlx_bind::{SqlxDialect, SqlxQuery, SqlxQueryAs};

--- a/src/sqlx_bind.rs
+++ b/src/sqlx_bind.rs
@@ -248,17 +248,35 @@ impl SqlxDialect for Sqlite {
     }
 }
 
+/// The `sqlx::query::Query` type a [`QueryBuilder<D>`] hands off to.
+pub type SqlxQuery<'q, D> = sqlx::query::Query<
+    'q,
+    <D as SqlxDialect>::Database,
+    <<D as SqlxDialect>::Database as sqlx::Database>::Arguments,
+>;
+
+/// The `sqlx::query::QueryAs` type a [`QueryBuilder<D>`] hands off to,
+/// decoding rows into `T`.
+pub type SqlxQueryAs<'q, D, T> = sqlx::query::QueryAs<
+    'q,
+    <D as SqlxDialect>::Database,
+    T,
+    <<D as SqlxDialect>::Database as sqlx::Database>::Arguments,
+>;
+
 #[cfg(any(
     feature = "sqlx_postgres",
     feature = "sqlx_mysql",
     feature = "sqlx_sqlite"
 ))]
 impl<D: SqlxDialect> QueryBuilder<D> {
-    /// Build an executable `sqlx::query::Query` from this builder.
+    /// Build an executable `sqlx::query::Query` from this builder, panicking on
+    /// an invalid builder.
     ///
     /// The SQL is builder-generated with bound placeholders, so it is asserted
     /// safe via `sqlx::AssertSqlSafe` (which also satisfies sqlx 0.9's `'static`
-    /// SQL bound). Mirrors 1.x `ChainBuilder::to_sqlx_query`.
+    /// SQL bound). Mirrors 1.x `ChainBuilder::to_sqlx_query`. Panicking twin of
+    /// [`Self::try_to_sqlx_query`].
     pub fn to_sqlx_query(
         &self,
     ) -> sqlx::query::Query<'_, D::Database, <D::Database as sqlx::Database>::Arguments> {
@@ -266,7 +284,20 @@ impl<D: SqlxDialect> QueryBuilder<D> {
         sqlx::query_with(sqlx::AssertSqlSafe(sql), D::bind_arguments(&binds))
     }
 
-    /// Build an executable `sqlx::query::QueryAs` decoding rows into `T`.
+    /// Build an executable `sqlx::query::Query`, or return the
+    /// [`BuildError`](crate::BuildError) when the builder is invalid (see
+    /// [`try_to_sql`](QueryBuilder::try_to_sql)).
+    pub fn try_to_sqlx_query(&self) -> Result<SqlxQuery<'_, D>, crate::BuildError> {
+        let (sql, binds) = self.try_to_sql()?;
+        Ok(sqlx::query_with(
+            sqlx::AssertSqlSafe(sql),
+            D::bind_arguments(&binds),
+        ))
+    }
+
+    /// Build an executable `sqlx::query::QueryAs` decoding rows into `T`,
+    /// panicking on an invalid builder. Panicking twin of
+    /// [`Self::try_to_sqlx_query_as`].
     pub fn to_sqlx_query_as<T>(
         &self,
     ) -> sqlx::query::QueryAs<'_, D::Database, T, <D::Database as sqlx::Database>::Arguments>
@@ -275,5 +306,19 @@ impl<D: SqlxDialect> QueryBuilder<D> {
     {
         let (sql, binds) = self.to_sql();
         sqlx::query_as_with(sqlx::AssertSqlSafe(sql), D::bind_arguments(&binds))
+    }
+
+    /// Build an executable `sqlx::query::QueryAs` decoding rows into `T`, or
+    /// return the [`BuildError`](crate::BuildError) when the builder is invalid
+    /// (see [`try_to_sql`](QueryBuilder::try_to_sql)).
+    pub fn try_to_sqlx_query_as<T>(&self) -> Result<SqlxQueryAs<'_, D, T>, crate::BuildError>
+    where
+        T: for<'r> sqlx::FromRow<'r, <D::Database as sqlx::Database>::Row>,
+    {
+        let (sql, binds) = self.try_to_sql()?;
+        Ok(sqlx::query_as_with(
+            sqlx::AssertSqlSafe(sql),
+            D::bind_arguments(&binds),
+        ))
     }
 }

--- a/tests/build_error.rs
+++ b/tests/build_error.rs
@@ -1,0 +1,272 @@
+//! `BuildError` / `try_to_sql()` — fallible compilation.
+//!
+//! Every fail-loud guard that panics in `to_sql()` must surface as a typed
+//! `Err(BuildError)` from `try_to_sql()` (and the sqlx handoff twins
+//! `try_to_sqlx_query` / `try_to_sqlx_query_as`), so web apps can map invalid
+//! query construction to an HTTP 4XX/5XX instead of crashing. `to_sql()`
+//! keeps its panicking behavior (same messages) for backward compatibility.
+
+use chain_builder::{BuildError, MySql, Postgres, QueryBuilder, Value};
+
+#[test]
+fn offset_without_limit_errs() {
+    let err = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .offset(10)
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::OffsetWithoutLimit);
+    assert_eq!(err.to_string(), "offset(...) requires limit(...)");
+}
+
+#[test]
+fn lock_on_non_select_errs() {
+    let err = QueryBuilder::<Postgres>::table("users")
+        .update([("status", "x")])
+        .for_update()
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::LockRequiresSelect);
+    assert_eq!(
+        err.to_string(),
+        "for_update()/for_share() is only valid on SELECT"
+    );
+}
+
+#[test]
+fn distinct_on_requires_postgres_errs() {
+    let err = QueryBuilder::<MySql>::table("users")
+        .select(["id"])
+        .distinct_on(["id"])
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::DistinctOnRequiresPostgres);
+    assert_eq!(err.to_string(), "DISTINCT ON requires PostgreSQL");
+}
+
+#[test]
+fn empty_insert_errs() {
+    let err = QueryBuilder::<Postgres>::table("users")
+        .insert(std::iter::empty::<(&str, Value)>())
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::EmptyInsert);
+    assert_eq!(err.to_string(), "insert() requires at least one column");
+}
+
+#[test]
+fn empty_update_errs() {
+    let err = QueryBuilder::<Postgres>::table("users")
+        .update(std::iter::empty::<(&str, Value)>())
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::EmptyUpdate);
+    assert_eq!(err.to_string(), "update() requires at least one column");
+}
+
+#[test]
+fn lock_with_union_errs() {
+    let err = QueryBuilder::<Postgres>::table("a")
+        .select(["id"])
+        .union(QueryBuilder::<Postgres>::table("b").select(["id"]))
+        .for_update()
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::LockWithUnion);
+    assert_eq!(
+        err.to_string(),
+        "for_update()/for_share() cannot be combined with UNION"
+    );
+}
+
+#[test]
+fn invalid_having_operator_is_deferred_not_a_call_time_panic() {
+    // Building with a bad operator must NOT panic at the `having()` call —
+    // the error is recorded and surfaces from `try_to_sql()`.
+    let qb = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .having("amount", "; DROP TABLE users", 0i64);
+    let err = qb.try_to_sql().unwrap_err();
+    assert_eq!(
+        err,
+        BuildError::InvalidHavingOperator("; DROP TABLE users".to_owned())
+    );
+    assert!(err.to_string().contains("not an allowed"));
+}
+
+#[test]
+fn first_deferred_error_wins() {
+    let err = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .having("a", "BAD-OP-1", 1i64)
+        .having("b", "BAD-OP-2", 2i64)
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(
+        err,
+        BuildError::InvalidHavingOperator("BAD-OP-1".to_owned())
+    );
+}
+
+#[test]
+fn deferred_error_propagates_from_cte() {
+    let bad_inner = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .having("amount", "UNION SELECT", 0i64);
+    let err = QueryBuilder::<Postgres>::table("top")
+        .select(["user_id"])
+        .with("top", bad_inner)
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(
+        err,
+        BuildError::InvalidHavingOperator("UNION SELECT".to_owned())
+    );
+}
+
+#[test]
+fn deferred_error_propagates_from_union_arm() {
+    let bad_arm = QueryBuilder::<Postgres>::table("b")
+        .select(["id"])
+        .having("x", "NOPE", 1i64);
+    let err = QueryBuilder::<Postgres>::table("a")
+        .select(["id"])
+        .union(bad_arm)
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::InvalidHavingOperator("NOPE".to_owned()));
+}
+
+#[test]
+fn deferred_error_propagates_from_select_subquery() {
+    let bad_sub = QueryBuilder::<Postgres>::table("orders")
+        .select(["amount"])
+        .having("amount", "OOPS", 1i64);
+    let err = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .select_subquery("total", bad_sub)
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::InvalidHavingOperator("OOPS".to_owned()));
+}
+
+#[test]
+fn deferred_error_propagates_from_where_exists() {
+    let bad_sub = QueryBuilder::<Postgres>::table("orders")
+        .select(["id"])
+        .having("id", "OOPS", 1i64);
+    let err = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_exists(bad_sub)
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::InvalidHavingOperator("OOPS".to_owned()));
+}
+
+#[test]
+fn deferred_error_propagates_from_where_in_subquery() {
+    let bad_sub = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .having("user_id", "OOPS", 1i64);
+    let err = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_in_subquery("id", bad_sub)
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err, BuildError::InvalidHavingOperator("OOPS".to_owned()));
+}
+
+#[test]
+fn valid_query_try_to_sql_ok() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .limit(10)
+        .offset(20)
+        .try_to_sql()
+        .unwrap();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "status" = $1 LIMIT $2 OFFSET $3"#
+    );
+    assert_eq!(binds.len(), 3);
+}
+
+#[test]
+fn valid_having_still_compiles_via_try_to_sql() {
+    let (sql, _) = QueryBuilder::<Postgres>::table("orders")
+        .select(["user_id"])
+        .group_by(["user_id"])
+        .having("total", ">", 100i64)
+        .try_to_sql()
+        .unwrap();
+    assert_eq!(
+        sql,
+        r#"SELECT "user_id" FROM "orders" GROUP BY "user_id" HAVING "total" > $1"#
+    );
+}
+
+#[test]
+fn build_error_is_std_error_send_sync() {
+    fn assert_traits<E: std::error::Error + Send + Sync + 'static>() {}
+    assert_traits::<BuildError>();
+}
+
+#[test]
+fn try_compile_is_exported() {
+    let qb = QueryBuilder::<Postgres>::table("users").select(["id"]);
+    let (sql, _) = chain_builder::try_compile(&qb).unwrap();
+    assert_eq!(sql, r#"SELECT "id" FROM "users""#);
+}
+
+// ---- sqlx handoff twins (MySql = default `sqlx_mysql` feature) ----
+
+#[cfg(feature = "sqlx_mysql")]
+mod sqlx_handoff {
+    use super::*;
+
+    #[test]
+    fn try_to_sqlx_query_errs_on_invalid_builder() {
+        let err = QueryBuilder::<MySql>::table("users")
+            .select(["id"])
+            .offset(5)
+            .try_to_sqlx_query()
+            .map(|_| ())
+            .unwrap_err();
+        assert_eq!(err, BuildError::OffsetWithoutLimit);
+    }
+
+    #[test]
+    fn try_to_sqlx_query_ok_on_valid_builder() {
+        assert!(QueryBuilder::<MySql>::table("users")
+            .select(["id"])
+            .where_eq("status", "active")
+            .try_to_sqlx_query()
+            .is_ok());
+    }
+
+    #[derive(sqlx::FromRow)]
+    #[allow(dead_code)]
+    struct UserRow {
+        id: i64,
+    }
+
+    #[test]
+    fn try_to_sqlx_query_as_errs_on_invalid_builder() {
+        let err = QueryBuilder::<MySql>::table("users")
+            .select(["id"])
+            .having("id", "BAD", 1i64)
+            .try_to_sqlx_query_as::<UserRow>()
+            .map(|_| ())
+            .unwrap_err();
+        assert_eq!(err, BuildError::InvalidHavingOperator("BAD".to_owned()));
+    }
+
+    #[test]
+    fn try_to_sqlx_query_as_ok_on_valid_builder() {
+        assert!(QueryBuilder::<MySql>::table("users")
+            .select(["id"])
+            .try_to_sqlx_query_as::<UserRow>()
+            .is_ok());
+    }
+}

--- a/tests/fetch.rs
+++ b/tests/fetch.rs
@@ -18,7 +18,7 @@ mod pg {
         name: String,
     }
 
-    async fn _typechecks(pool: sqlx::PgPool) -> Result<(), sqlx::Error> {
+    async fn _typechecks(pool: sqlx::PgPool) -> Result<(), chain_builder::Error> {
         let qb = QueryBuilder::<Postgres>::table("users")
             .select(["id", "name"])
             .where_gt("id", 0i64);
@@ -57,7 +57,7 @@ mod mysql {
         name: String,
     }
 
-    async fn _typechecks(pool: sqlx::MySqlPool) -> Result<(), sqlx::Error> {
+    async fn _typechecks(pool: sqlx::MySqlPool) -> Result<(), chain_builder::Error> {
         let qb = QueryBuilder::<MySql>::table("users")
             .select(["id", "name"])
             .where_gt("id", 0i64);
@@ -96,7 +96,7 @@ mod sqlite {
         name: String,
     }
 
-    async fn _typechecks(pool: sqlx::SqlitePool) -> Result<(), sqlx::Error> {
+    async fn _typechecks(pool: sqlx::SqlitePool) -> Result<(), chain_builder::Error> {
         let qb = QueryBuilder::<Sqlite>::table("users")
             .select(["id", "name"])
             .where_gt("id", 0i64);

--- a/tests/fetch_error.rs
+++ b/tests/fetch_error.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "sqlx_sqlite")]
+//! `fetch_*` / `execute` / `count` return the unified [`chain_builder::Error`]:
+//! an invalid builder surfaces as `Error::Build(BuildError)` BEFORE touching
+//! the database, and a database failure surfaces as `Error::Sqlx(sqlx::Error)`
+//! — no panic on either path.
+
+use chain_builder::{BuildError, Error, QueryBuilder, Sqlite};
+
+#[derive(Debug, sqlx::FromRow, PartialEq)]
+struct User {
+    id: i64,
+    name: String,
+}
+
+async fn pool() -> sqlx::SqlitePool {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::query("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    pool
+}
+
+#[tokio::test]
+async fn invalid_builder_fetch_all_errs_with_build_error() {
+    let pool = pool().await;
+    let err = QueryBuilder::<Sqlite>::table("users")
+        .select(["id", "name"])
+        .offset(5) // offset without limit → BuildError, not a panic
+        .fetch_all::<User, _>(&pool)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::Build(BuildError::OffsetWithoutLimit)));
+}
+
+#[tokio::test]
+async fn invalid_builder_execute_errs_with_build_error() {
+    let pool = pool().await;
+    let err = QueryBuilder::<Sqlite>::table("users")
+        .update(std::iter::empty::<(&str, i64)>())
+        .execute(&pool)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::Build(BuildError::EmptyUpdate)));
+}
+
+#[tokio::test]
+async fn invalid_builder_count_errs_with_build_error() {
+    let pool = pool().await;
+    let err = QueryBuilder::<Sqlite>::table("users")
+        .select(["id"])
+        .having("id", "BAD-OP", 1i64)
+        .count(&pool)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::Build(BuildError::InvalidHavingOperator(_))
+    ));
+}
+
+#[tokio::test]
+async fn database_failure_errs_with_sqlx_error() {
+    let pool = pool().await;
+    let err = QueryBuilder::<Sqlite>::table("no_such_table")
+        .select(["id", "name"])
+        .fetch_all::<User, _>(&pool)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::Sqlx(_)));
+}
+
+#[tokio::test]
+async fn valid_query_round_trips_ok() {
+    let pool = pool().await;
+    use chain_builder::Value;
+    QueryBuilder::<Sqlite>::table("users")
+        .insert([("id", Value::I64(1)), ("name", Value::Text("Ann".into()))])
+        .execute(&pool)
+        .await
+        .unwrap();
+    let rows: Vec<User> = QueryBuilder::<Sqlite>::table("users")
+        .select(["id", "name"])
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![User {
+            id: 1,
+            name: "Ann".into()
+        }]
+    );
+}
+
+#[test]
+fn error_is_std_error_with_source() {
+    fn assert_traits<E: std::error::Error + Send + Sync + 'static>() {}
+    assert_traits::<Error>();
+
+    let e = Error::from(BuildError::OffsetWithoutLimit);
+    assert_eq!(e.to_string(), "offset(...) requires limit(...)");
+    assert!(std::error::Error::source(&e).is_some());
+}
+
+#[test]
+fn error_converts_from_both_sides() {
+    let _: Error = BuildError::EmptyInsert.into();
+    let _: Error = sqlx::Error::RowNotFound.into();
+}

--- a/tests/having_guard.rs
+++ b/tests/having_guard.rs
@@ -5,7 +5,9 @@
 //! runtime string, `having()` takes `op: &str` for ergonomics. To keep that
 //! from becoming a SQL-injection vector when a caller wires an
 //! attacker-controlled operator into the HAVING clause, the operator is
-//! validated against a fixed allowlist and a disallowed operator panics
+//! validated against a fixed allowlist. A disallowed operator records a
+//! deferred `BuildError`: `try_to_sql()` returns it as `Err` (covered in
+//! `tests/build_error.rs`), while `to_sql()` panics with the same message
 //! (fail-loud, matching the `offset`/`distinct_on`/lock guards). Arbitrary
 //! aggregate expressions go through `having_raw` instead.
 


### PR DESCRIPTION
## Summary

Converts every fail-loud `panic!` guard into a typed error so web apps can map invalid query construction to HTTP 4XX/5XX instead of crashing.

- **New `BuildError`** (`#[non_exhaustive]`, `std::error::Error`): `LockRequiresSelect`, `DistinctOnRequiresPostgres`, `EmptyInsert`, `EmptyUpdate`, `OffsetWithoutLimit`, `LockWithUnion`, `InvalidHavingOperator(String)`.
- **New fallible twins**: `try_to_sql()`, `try_compile()`, `try_to_sqlx_query()`, `try_to_sqlx_query_as()`. Panicking API kept deliberately (documented policy); panic messages unchanged byte-for-byte.
- **`having()` deferred error**: a disallowed operator no longer panics at the call site — recorded on the builder (first error wins), surfaces at compile time, propagates through CTEs/UNION arms/subqueries.
- **BREAKING**: `fetch_all`/`fetch_one`/`fetch_optional`/`execute`/`count`/`fetch_scalar`/`fetch_optional_scalar` now return `Result<_, chain_builder::Error>` (`Error::Build` before touching the DB, `Error::Sqlx` for driver failures).
- `SqlxQuery`/`SqlxQueryAs` aliases re-exported at root; guide + CHANGELOG updated; builder doctests un-gated from the nonexistent `v2` feature (now actually run).

## Test plan

- 28 new tests: `tests/build_error.rs` (21, incl. nested-builder propagation pins), `tests/fetch_error.rs` (7, live SQLite, both error modes)
- Full suite green on `--all-features` (227 passed) and on publish.yml's combo `sqlx_postgres,sqlx_sqlite` (214 passed)
- `cargo publish --dry-run` OK, clippy 0 warnings, fmt clean, `--no-default-features` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)