### PR TITLE
feat: 3.1.0 Tier-1 — UPDATE expressions, group subqueries, escape_like, to_sql_pretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Subquery predicates inside `and_where`/`or_where` groups.**
+  `WhereBuilder` gains `where_exists`, `where_not_exists`,
+  `where_in_subquery`, `where_not_in_subquery`, mirroring the `QueryBuilder`
+  methods (same contracts, placeholder continuity included) — closing the
+  group/top-level API asymmetry.
+- **UPDATE expressions.** `set_raw(col, expr, binds)` (verbatim escape
+  hatch, `where_raw` placeholder contract), plus structured
+  `increment(col, by)` / `decrement(col, by)` for atomic counters. All
+  three switch the builder to UPDATE; expressions render after the sorted
+  `update()` columns, in call order. `EmptyUpdate` now fires only when both
+  the column set and the expression list are empty (message unchanged).
+- **`escape_like()`** at the crate root: escapes `\`, `%`, `_` so user
+  input matches literally in `LIKE`/`ILIKE` patterns (promoted from the
+  cookbook recipe; pair with an explicit `ESCAPE` clause for full
+  portability).
+- **`to_sql_pretty()` / `try_to_sql_pretty()`**: human-readable
+  `(sql, binds)` rendering for logs. Output includes literal bind values;
+  format is not a stability contract. Twin-API policy applies (panicking
+  twin's message is the `BuildError` Display text).
+
 ## [3.0.0] - 2026-06-10
 
 ### Added

--- a/docs/book/src/binds.md
+++ b/docs/book/src/binds.md
@@ -205,6 +205,29 @@ feature enabled, `to_sqlx_query()` and the `fetch_*` helpers translate each
 `Value` into the backend's argument buffer and execute it — the SQL string
 still never contains a value. See [Executing with sqlx](sqlx.md).
 
+## Inspecting a query: `to_sql_pretty`
+
+For logs and debugging, `to_sql_pretty()` (3.1.0+) renders the SQL plus one
+line per bind. `try_to_sql_pretty()` is the fallible twin and surfaces the
+same `BuildError` as `try_to_sql()`:
+
+```rust,ignore
+let qb = QueryBuilder::<Postgres>::table("users")
+    .select(["id"])
+    .where_eq("status", "active")
+    .where_gt("age", 21i64);
+println!("{}", qb.to_sql_pretty());
+// SELECT "id" FROM "users" WHERE "status" = $1 AND "age" > $2
+// binds:
+//   $1 = Text("active")
+//   $2 = I64(21)
+```
+
+On `?`-placeholder dialects (MySQL/SQLite) the bind labels carry a 1-based
+ordinal for readability (`?1 = …`); the SQL itself still uses bare `?`. The
+output includes the literal bind values — don't log it if a bind may carry
+sensitive data. The output format is for humans — not a stability contract.
+
 ## Related pages
 
 - [Security Model](security.md) — why values are always bound, and what raw fragments do not protect

--- a/docs/book/src/binds.md
+++ b/docs/book/src/binds.md
@@ -197,14 +197,6 @@ Bound **natively** on Postgres (`NUMERIC`) and MySQL (`DECIMAL`).
 > exact storage/round-trip only; for numeric range queries, store a scaled
 > integer (cents) or compare with `CAST(price AS REAL)`.
 
-## Where the binds go from here
-
-`to_sql()` / `try_to_sql()` stop at `(String, Vec<Value>)` — useful for
-logging, testing, or driving a non-sqlx driver yourself. With a `sqlx_*`
-feature enabled, `to_sqlx_query()` and the `fetch_*` helpers translate each
-`Value` into the backend's argument buffer and execute it — the SQL string
-still never contains a value. See [Executing with sqlx](sqlx.md).
-
 ## Inspecting a query: `to_sql_pretty`
 
 For logs and debugging, `to_sql_pretty()` (3.1.0+) renders the SQL plus one
@@ -227,6 +219,14 @@ On `?`-placeholder dialects (MySQL/SQLite) the bind labels carry a 1-based
 ordinal for readability (`?1 = …`); the SQL itself still uses bare `?`. The
 output includes the literal bind values — don't log it if a bind may carry
 sensitive data. The output format is for humans — not a stability contract.
+
+## Where the binds go from here
+
+`to_sql()` / `try_to_sql()` stop at `(String, Vec<Value>)` — useful for
+logging, testing, or driving a non-sqlx driver yourself. With a `sqlx_*`
+feature enabled, `to_sqlx_query()` and the `fetch_*` helpers translate each
+`Value` into the backend's argument buffer and execute it — the SQL string
+still never contains a value. See [Executing with sqlx](sqlx.md).
 
 ## Related pages
 

--- a/docs/book/src/cookbook/search.md
+++ b/docs/book/src/cookbook/search.md
@@ -68,7 +68,7 @@ The portable fix is an explicit `ESCAPE` clause, which the structured
 [`where_raw`](../query/where.md) job:
 
 ```rust,ignore
-use chain_builder::{Postgres, QueryBuilder, Value};
+use chain_builder::{escape_like, Postgres, QueryBuilder, Value};
 
 let q = "50%"; // raw user input
 let pattern = format!("%{}%", escape_like(q)); // "%50\%%"

--- a/docs/book/src/cookbook/search.md
+++ b/docs/book/src/cookbook/search.md
@@ -48,18 +48,12 @@ correctness and abuse problem: a filter that should narrow results can be
 forced wide open, and pathological patterns (`%a%b%c%d%…`) make the database
 scan hard.
 
-Escape the three metacharacters yourself before splicing input into a
-pattern (backslash first — order matters):
+Escape the three metacharacters before splicing input into a pattern —
+backslash first, then `%` and `_` (order matters, or the backslashes
+produced for `%`/`_` get double-escaped). The crate ships exactly this:
 
 ```rust,ignore
-/// Escape LIKE/ILIKE metacharacters so user input matches literally.
-/// `\` must be escaped first, then `%` and `_`.
-fn escape_like(input: &str) -> String {
-    input
-        .replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_")
-}
+use chain_builder::escape_like; // in-crate since 3.1.0
 
 assert_eq!(escape_like("100%_a\\b"), "100\\%\\_a\\\\b");
 ```
@@ -90,11 +84,11 @@ let (sql, binds) = QueryBuilder::<Postgres>::table("users")
     )
     .to_sql();
 // SELECT "id", "name" FROM "users" WHERE "status" = $1 AND LOWER("name") LIKE LOWER($2) ESCAPE '\'
+```
 
 On MySQL, write the escape literal as `ESCAPE '\\'` — inside a MySQL string
 literal a single backslash escapes the closing quote, so `'\'` is a syntax
 error. (SQLite accepts `'\'` as-is.)
-```
 
 Now `50%` matches only names containing the literal text `50%`. Mind the
 `where_raw` contract: the fragment is emitted verbatim — hand-write the

--- a/docs/book/src/query/insert-update-delete.md
+++ b/docs/book/src/query/insert-update-delete.md
@@ -181,8 +181,10 @@ valid SQL, so the compiler refuses to render it:
 
 - empty `insert(…)` / `insert_many(…)` → `BuildError::EmptyInsert`
   (`insert() requires at least one column`)
-- empty `update(…)` → `BuildError::EmptyUpdate`
-  (`update() requires at least one column`)
+- `update(…)` with no columns **and** no `SET` expressions →
+  `BuildError::EmptyUpdate` (`update() requires at least one column`).
+  An empty `update(…)` plus an `increment`/`decrement`/`set_raw` is a
+  valid UPDATE (3.1.0+).
 
 As always, [`try_to_sql()`](../error-handling.md) returns the error and
 `to_sql()` panics with the same message:

--- a/docs/book/src/query/insert-update-delete.md
+++ b/docs/book/src/query/insert-update-delete.md
@@ -126,6 +126,32 @@ let (sql, binds) = QueryBuilder::<Postgres>::table("users")
 // binds == [Value::I64(2), Value::Text("a".into()), Value::I64(1)]
 ```
 
+## UPDATE expressions: `set_raw`, `increment`, `decrement`
+
+Plain `update()` can only bind values (`SET "col" = $1`). Three companions
+cover computed assignments (3.1.0+). All three switch the builder to UPDATE,
+so `increment` alone is a valid statement:
+
+```rust,ignore
+use chain_builder::{Postgres, QueryBuilder, Value};
+
+let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+    .update([("name", "x")])
+    .increment("views", 1i64)
+    .set_raw("updated_at", "NOW()", vec![])
+    .where_eq("id", 9i64)
+    .to_sql();
+// UPDATE "t" SET "name" = $1, "views" = "views" + $2, "updated_at" = NOW() WHERE "id" = $3
+```
+
+Ordering: the (sorted) `update()` columns render first, then expressions in
+call order. `increment`/`decrement` are fully structured — column escaped,
+amount bound. `set_raw` is the verbatim escape hatch and follows the same
+positional-placeholder contract as `where_raw`: on Postgres hand-write `$N`
+counting all binds accumulated so far (`SET` precedes `WHERE`, and a
+preceding `increment`/`decrement` counts as one bind); on MySQL/SQLite use
+`?`. Duplicate target columns are not detected — the database reports them.
+
 ## `delete()`
 
 `delete` takes no arguments; WHERE applies as usual:

--- a/docs/book/src/query/where.md
+++ b/docs/book/src/query/where.md
@@ -191,10 +191,8 @@ let (sql, binds) = QueryBuilder::<Postgres>::table("users")
 ## Groups: `and_where` / `or_where`
 
 To get parentheses and `OR`, pass a closure to `and_where` or `or_where`. The
-closure receives a `WhereBuilder` exposing the predicate methods — everything
-except the subquery predicates (`where_exists`, `where_not_exists`,
-`where_in_subquery`, `where_not_in_subquery`) — plus `and_where`/`or_where`
-again, so groups nest. The method name decides how the
+closure receives a `WhereBuilder` exposing the predicate methods, plus
+`and_where`/`or_where` again, so groups nest. The method name decides how the
 group attaches to what precedes it (`AND (…)` vs `OR (…)`); inside the group,
 predicates are joined with `AND` unless they are themselves `or_where`
 sub-groups:
@@ -215,6 +213,29 @@ let (sql, binds) = QueryBuilder::<Postgres>::table("t")
     .and_where(|g| g.where_eq("a", 1i64).or_where(|h| h.where_eq("b", 2i64)))
     .to_sql();
 // SELECT * FROM "t" WHERE ("a" = $1 OR ("b" = $2))
+```
+
+Since 3.1.0 the four subquery predicates are also available **inside**
+groups, with the same contracts (placeholder continuity included):
+
+```rust,ignore
+let (sql, _) = QueryBuilder::<Postgres>::table("users")
+    .select(["id"])
+    .and_where(|g| {
+        g.where_in_subquery(
+            "id",
+            QueryBuilder::<Postgres>::table("ban")
+                .select(["user_id"])
+                .where_eq("k", 7i64),
+        )
+        .where_not_exists(
+            QueryBuilder::<Postgres>::table("audit")
+                .select(["1"])
+                .where_eq("level", 3i64),
+        )
+    })
+    .to_sql();
+// SELECT "id" FROM "users" WHERE ("id" IN (SELECT "user_id" FROM "ban" WHERE "k" = $1) AND NOT EXISTS (SELECT "1" FROM "audit" WHERE "level" = $2))
 ```
 
 Two edge cases are handled for you:

--- a/docs/book/src/security.md
+++ b/docs/book/src/security.md
@@ -89,7 +89,7 @@ the type level everywhere else.
 
 ## Escape-hatch inventory (complete)
 
-Six methods accept raw SQL. All six share the same contract:
+Seven methods accept raw SQL. All seven share the same contract:
 
 > The fragment is emitted **verbatim** — not escaped, not validated, not
 > renumbered. Its binds are appended to the running bind list in order. On
@@ -105,6 +105,7 @@ Six methods accept raw SQL. All six share the same contract:
 | `group_by_raw(sql, Vec<Value>)` | GROUP BY, after structured columns |
 | `order_by_raw(sql, Vec<Value>)` | ORDER BY, after structured terms |
 | `having_raw(sql, Vec<Value>)` | HAVING, as one term |
+| `set_raw(col, sql, Vec<Value>)` | UPDATE SET, as `"col" = <fragment>` after the structured columns (the column identifier IS escaped; only the right-hand side is verbatim) |
 | `JoinClause::on_raw(sql, Vec<Value>)` | JOIN … ON, as one condition |
 
 Never feed request input — even "just a column name" — into a raw fragment.

--- a/docs/superpowers/plans/2026-06-10-v3.1-tier1.md
+++ b/docs/superpowers/plans/2026-06-10-v3.1-tier1.md
@@ -1,0 +1,931 @@
+# chain-builder 3.1.0 Tier-1 Features Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship four additive 3.1.0 features: subquery predicates on `WhereBuilder`, `escape_like()`, UPDATE expressions (`set_raw`/`increment`/`decrement`), and `to_sql_pretty()`/`try_to_sql_pretty()`.
+
+**Architecture:** Pure additions per the spec at `docs/superpowers/specs/2026-06-10-v3.1-tier1-design.md`. New `set_exprs: Vec<SetExpr>` field on `QueryBuilder` (the shared/sorted `set` field is untouched); four `WhereBuilder` methods pushing existing `Predicate` variants (zero compiler changes); a standalone `escape_like` function; pretty-printing built on `try_compile` + `Dialect::write_placeholder`.
+
+**Tech Stack:** Rust, no new dependencies. Tests are byte-exact SQL assertions in `tests/`. Spec: `docs/superpowers/specs/2026-06-10-v3.1-tier1-design.md` — read it before starting any task.
+
+**Conventions that apply to every task:**
+- TDD: write the failing test, see it fail, implement, see it pass.
+- Run tests with `cargo test --all-features` (full suite must stay green; baseline 227 + whatever earlier tasks added).
+- Do NOT reformat unrelated code. Run `cargo fmt` before each commit.
+- Commit messages follow the repo's `feat:`/`docs:`/`test:` style.
+
+---
+
+### Task 1: Subquery predicates on `WhereBuilder`
+
+**Files:**
+- Modify: `src/where_.rs` (add four methods to `impl WhereBuilder<D>`, after `where_column` which ends around line 329)
+- Test: `tests/subquery.rs` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/subquery.rs`:
+
+```rust
+// --- 3.1.0: subquery predicates inside and_where / or_where groups ---
+
+#[test]
+fn pg_group_where_exists_continuity() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("active", true)
+        .and_where(|g| {
+            g.where_exists(
+                QueryBuilder::<Postgres>::table("orders")
+                    .select(["1"])
+                    .where_column("orders.user_id", "=", "users.id")
+                    .where_gt("total", 100i64),
+            )
+            .or_where(|h| h.where_eq("vip", true))
+        })
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "active" = $1 AND (EXISTS (SELECT "1" FROM "orders" WHERE "orders"."user_id" = "users"."id" AND "total" > $2) OR ("vip" = $3))"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Bool(true), Value::I64(100), Value::Bool(true)]
+    );
+}
+
+#[test]
+fn pg_group_in_subquery_and_not_exists() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .and_where(|g| {
+            g.where_in_subquery(
+                "id",
+                QueryBuilder::<Postgres>::table("ban")
+                    .select(["user_id"])
+                    .where_eq("k", 7i64),
+            )
+            .where_not_exists(QueryBuilder::<Postgres>::table("audit").select(["1"]))
+        })
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE ("id" IN (SELECT "user_id" FROM "ban" WHERE "k" = $1) AND NOT EXISTS (SELECT "1" FROM "audit"))"#
+    );
+    assert_eq!(binds, vec![Value::I64(7)]);
+}
+
+#[test]
+fn mysql_group_not_in_subquery() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("users")
+        .select(["id"])
+        .and_where(|g| {
+            g.where_not_in_subquery(
+                "id",
+                QueryBuilder::<MySql>::table("ban")
+                    .select(["user_id"])
+                    .where_eq("k", 7i64),
+            )
+        })
+        .to_sql();
+    assert_eq!(
+        sql,
+        "SELECT `id` FROM `users` WHERE (`id` NOT IN (SELECT `user_id` FROM `ban` WHERE `k` = ?))"
+    );
+    assert_eq!(binds, vec![Value::I64(7)]);
+}
+```
+
+If a byte-exact expectation for the EXISTS / IN fragment disagrees with the
+compiler's actual output once the methods exist, the authority is the existing
+top-level tests in this same file (`pg_where_exists_placeholder_continuity`
+etc.) — the group version must render the identical fragment inside the
+parens. Fix the *expectation*, not the compiler.
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `cargo test --test subquery 2>&1 | tail -20`
+Expected: compile error — `no method named 'where_exists' found for struct 'WhereBuilder'`
+
+- [ ] **Step 3: Implement the four methods**
+
+In `src/where_.rs`, inside `impl<D: Dialect> WhereBuilder<D>`, after `where_column` (ends ~line 329):
+
+```rust
+    /// `EXISTS (subquery)` inside this group. Mirrors
+    /// [`QueryBuilder::where_exists`](crate::QueryBuilder::where_exists) —
+    /// same contract, including placeholder continuity into the sub-query.
+    pub fn where_exists(mut self, sub: QueryBuilder<D>) -> Self {
+        self.preds.push(Predicate::Exists {
+            neg: false,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `NOT EXISTS (subquery)` inside this group. See
+    /// [`QueryBuilder::where_not_exists`](crate::QueryBuilder::where_not_exists).
+    pub fn where_not_exists(mut self, sub: QueryBuilder<D>) -> Self {
+        self.preds.push(Predicate::Exists {
+            neg: true,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `col IN (subquery)` inside this group. Mirrors
+    /// [`QueryBuilder::where_in_subquery`](crate::QueryBuilder::where_in_subquery).
+    pub fn where_in_subquery(mut self, col: &str, sub: QueryBuilder<D>) -> Self {
+        self.preds.push(Predicate::InSubquery {
+            col: col.to_owned(),
+            neg: false,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `col NOT IN (subquery)` inside this group. See
+    /// [`QueryBuilder::where_not_in_subquery`](crate::QueryBuilder::where_not_in_subquery).
+    pub fn where_not_in_subquery(mut self, col: &str, sub: QueryBuilder<D>) -> Self {
+        self.preds.push(Predicate::InSubquery {
+            col: col.to_owned(),
+            neg: true,
+            sub: Box::new(sub),
+        });
+        self
+    }
+```
+
+`QueryBuilder` is already imported in `where_.rs` (line 10) and the
+`Exists`/`InSubquery` variants already exist (lines ~117-132). No
+`src/compile.rs` change.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test subquery`
+Expected: all tests in the file PASS (existing + 3 new)
+
+- [ ] **Step 5: Full suite + fmt + commit**
+
+```bash
+cargo fmt && cargo test --all-features --quiet 2>&1 | tail -5
+git add src/where_.rs tests/subquery.rs
+git commit -m "feat: subquery predicates on WhereBuilder groups"
+```
+Expected: suite green (230 unit/integration tests at this point).
+
+---
+
+### Task 2: `escape_like()`
+
+**Files:**
+- Create: `src/like.rs`
+- Modify: `src/lib.rs` (module + export, near line 51-59)
+- Test: `tests/escape_like.rs` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/escape_like.rs`:
+
+```rust
+//! 3.1.0: `escape_like` — LIKE-pattern metacharacter escaping.
+
+use chain_builder::escape_like;
+
+#[test]
+fn pinned_cookbook_assertion() {
+    // Byte-identical to the recipe in docs/book/src/cookbook/search.md.
+    assert_eq!(escape_like("100%_a\\b"), "100\\%\\_a\\\\b");
+}
+
+#[test]
+fn empty_input_is_empty() {
+    assert_eq!(escape_like(""), "");
+}
+
+#[test]
+fn input_without_metachars_is_unchanged() {
+    assert_eq!(escape_like("hello world"), "hello world");
+}
+
+#[test]
+fn each_metachar_escaped() {
+    assert_eq!(escape_like("%"), "\\%");
+    assert_eq!(escape_like("_"), "\\_");
+    assert_eq!(escape_like("\\"), "\\\\");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `cargo test --test escape_like 2>&1 | tail -10`
+Expected: compile error — `unresolved import 'chain_builder::escape_like'`
+
+- [ ] **Step 3: Implement**
+
+Create `src/like.rs`:
+
+```rust
+//! `LIKE`-pattern escaping helper.
+
+/// Escape `\`, `%`, and `_` so user input matches **literally** inside a
+/// `LIKE`/`ILIKE` pattern. The caller still wraps the result in `%…%` /
+/// `…%` as needed.
+///
+/// Backslash is escaped first (order matters), then `%` and `_`:
+///
+/// ```
+/// use chain_builder::escape_like;
+/// assert_eq!(escape_like("100%_a\\b"), "100\\%\\_a\\\\b");
+/// assert_eq!(format!("%{}%", escape_like("50%")), "%50\\%%");
+/// ```
+///
+/// # Portability caveat
+///
+/// What `\` means inside a `LIKE` pattern is dialect-defined: Postgres and
+/// MySQL treat backslash as the default escape character, but **SQLite has
+/// no default escape character at all**. For fully portable literal
+/// matching, pair the escaped pattern with an explicit `ESCAPE '\'` clause
+/// via `where_raw` (on MySQL write the literal as `ESCAPE '\\'`). See the
+/// search-pattern chapter of the book for the full recipe.
+pub fn escape_like(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+```
+
+In `src/lib.rs`: add `mod like;` next to the other module declarations, and
+add `pub use like::escape_like;` next to the existing re-exports (lines
+51-59).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test escape_like`
+Expected: 4 PASS. Also run `cargo test --doc 2>&1 | tail -3` — the new
+doctest must pass (doctest count goes from 4 run to 5 run, 1 ignored).
+
+- [ ] **Step 5: Full suite + fmt + commit**
+
+```bash
+cargo fmt && cargo test --all-features --quiet 2>&1 | tail -5
+git add src/like.rs src/lib.rs tests/escape_like.rs
+git commit -m "feat: escape_like() helper at crate root"
+```
+
+---
+
+### Task 3: UPDATE expressions — `set_raw` / `increment` / `decrement`
+
+**Files:**
+- Modify: `src/builder.rs` — `SetExpr` enum (define right after the existing `SelectExpr` enum, ~line 212-260), `set_exprs` field (after `set` at line 303), constructor init (after `set: Vec::new()` at line 348), three methods (after `update`, ends ~line 770)
+- Modify: `src/compile.rs` — `Method::Update` arm (lines 209-229), import `SetExpr` in the `use crate::builder::{…}` list (line 8)
+- Modify: `src/error.rs` — doc comment on `EmptyUpdate` (line 35-36 area); **Display text at line 54 unchanged**
+- Test: `tests/set_expr.rs` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/set_expr.rs`:
+
+```rust
+//! 3.1.0: UPDATE expressions — `set_raw`, `increment`, `decrement`.
+
+use chain_builder::{Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn pg_update_with_increment_and_raw() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .update([("name", "x")])
+        .increment("views", 1i64)
+        .set_raw("updated_at", "NOW()", vec![])
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "name" = $1, "views" = "views" + $2, "updated_at" = NOW() WHERE "id" = $3"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("x".into()), Value::I64(1), Value::I64(9)]
+    );
+}
+
+#[test]
+fn pg_increment_alone_is_a_valid_update() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .increment("views", 1i64)
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "views" = "views" + $1 WHERE "id" = $2"#
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(9)]);
+}
+
+#[test]
+fn pg_decrement_emits_minus() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .decrement("stock", 3i64)
+        .to_sql();
+    assert_eq!(sql, r#"UPDATE "t" SET "stock" = "stock" - $1"#);
+    assert_eq!(binds, vec![Value::I64(3)]);
+}
+
+#[test]
+fn pg_set_raw_own_binds_positions() {
+    // One structured SET bind ($1) precedes the raw expr, so its hand-written
+    // placeholder is $2; WHERE continues at $3.
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .update([("a", 1i64)])
+        .set_raw("total", "price * $2", vec![Value::I64(3)])
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "a" = $1, "total" = price * $2 WHERE "id" = $3"#
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(3), Value::I64(9)]);
+}
+
+#[test]
+fn sqlite_update_exprs_use_question_marks() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("t")
+        .update([("name", "x")])
+        .increment("views", 1i64)
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "name" = ?, "views" = "views" + ? WHERE "id" = ?"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("x".into()), Value::I64(1), Value::I64(9)]
+    );
+}
+
+#[test]
+fn exprs_only_update_does_not_err_empty() {
+    let res = QueryBuilder::<Postgres>::table("t")
+        .increment("v", 1i64)
+        .try_to_sql();
+    assert!(res.is_ok());
+}
+
+#[test]
+fn empty_update_still_errs() {
+    // Both `set` and `set_exprs` empty → EmptyUpdate, same Display text.
+    let err = QueryBuilder::<Postgres>::table("t")
+        .update(std::iter::empty::<(&str, Value)>())
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err.to_string(), "update() requires at least one column");
+}
+
+#[test]
+fn method_switch_away_from_update_ignores_exprs() {
+    // Last-call-wins: insert() after set_raw() — exprs are ignored, like
+    // leftover `set` state is today.
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("t")
+        .set_raw("x", "1", vec![])
+        .insert([("a", 1i64)])
+        .to_sql();
+    assert_eq!(sql, r#"INSERT INTO "t" ("a") VALUES (?)"#);
+    assert_eq!(binds, vec![Value::I64(1)]);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `cargo test --test set_expr 2>&1 | tail -10`
+Expected: compile error — `no method named 'increment'` / `'set_raw'`
+
+- [ ] **Step 3: Implement builder side**
+
+In `src/builder.rs`, right after the `SelectExpr` enum (line 212 onward, after its closing brace):
+
+```rust
+/// A structured or raw `SET` expression for UPDATE. Backs
+/// [`QueryBuilder::set_raw`] / [`QueryBuilder::increment`] /
+/// [`QueryBuilder::decrement`]. Rendered after the (sorted) structured
+/// `update()` columns, in call order.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum SetExpr {
+    /// `{esc col} = {expr verbatim}` with its own binds (NOT escaped or
+    /// renumbered — the `where_raw` contract).
+    Raw {
+        /// Column identifier; escaped in compile.rs.
+        col: String,
+        /// Verbatim RHS expression.
+        expr: String,
+        /// Binds appended to the running bind list in order.
+        binds: Vec<Value>,
+    },
+    /// `{esc col} = {esc col} {+|-} {placeholder}` — structured step.
+    Step {
+        /// Column identifier; escaped in compile.rs.
+        col: String,
+        /// The step amount, bound via the normal placeholder machinery.
+        by: Value,
+        /// `false` → `+` (increment); `true` → `-` (decrement).
+        neg: bool,
+    },
+}
+```
+
+Field, after `pub(crate) set: Vec<(String, Value)>,` (line 303):
+
+```rust
+    /// UPDATE `SET` expressions, rendered after the sorted `set` pairs in
+    /// call order. Backs `set_raw`/`increment`/`decrement`.
+    pub(crate) set_exprs: Vec<SetExpr>,
+```
+
+Constructor (`table()`, after `set: Vec::new(),` at line 348):
+
+```rust
+            set_exprs: Vec::new(),
+```
+
+Methods, after `update` (ends ~line 770):
+
+```rust
+    /// Set a column to a **verbatim** SQL expression — the UPDATE escape
+    /// hatch. Switches the builder to UPDATE, like [`Self::update`] (and
+    /// like every method-selecting call, last one wins: switching away from
+    /// UPDATE afterwards leaves the expressions ignored).
+    ///
+    /// `col` is identifier-escaped; `expr` is emitted verbatim with `binds`
+    /// appended. Expressions render after the (sorted) structured
+    /// [`Self::update`] columns, in call order. Duplicate target columns are
+    /// not detected — the database reports them.
+    ///
+    /// # Warning: positional placeholder contract
+    ///
+    /// `expr` is NOT escaped or renumbered. For **Postgres**, hand-write
+    /// `$N` matching the actual bind position — `SET` precedes `WHERE`, so
+    /// that is `structured SET binds + binds of earlier expressions + 1`,
+    /// `+2`, … For MySQL/SQLite use `?`. A wrong `$N` produces a malformed
+    /// query.
+    ///
+    /// ```
+    /// use chain_builder::{Postgres, QueryBuilder, Value};
+    /// let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+    ///     .update([("name", "x")])
+    ///     .set_raw("updated_at", "NOW()", vec![])
+    ///     .to_sql();
+    /// assert_eq!(sql, r#"UPDATE "t" SET "name" = $1, "updated_at" = NOW()"#);
+    /// assert_eq!(binds, vec![Value::Text("x".into())]);
+    /// ```
+    pub fn set_raw(mut self, col: &str, expr: &str, binds: Vec<Value>) -> Self {
+        self.method = Method::Update;
+        self.set_exprs.push(SetExpr::Raw {
+            col: col.to_owned(),
+            expr: expr.to_owned(),
+            binds,
+        });
+        self
+    }
+
+    /// `col = col + value` — atomic counter increment. Structured (column
+    /// escaped, value bound); switches the builder to UPDATE, so
+    /// `qb.increment("views", 1)` alone is a valid UPDATE.
+    ///
+    /// ```
+    /// use chain_builder::{Postgres, QueryBuilder, Value};
+    /// let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+    ///     .increment("views", 1i64)
+    ///     .to_sql();
+    /// assert_eq!(sql, r#"UPDATE "t" SET "views" = "views" + $1"#);
+    /// assert_eq!(binds, vec![Value::I64(1)]);
+    /// ```
+    pub fn increment(mut self, col: &str, by: impl IntoBind) -> Self {
+        self.method = Method::Update;
+        self.set_exprs.push(SetExpr::Step {
+            col: col.to_owned(),
+            by: by.into_bind(),
+            neg: false,
+        });
+        self
+    }
+
+    /// `col = col - value` — atomic counter decrement. See
+    /// [`Self::increment`].
+    pub fn decrement(mut self, col: &str, by: impl IntoBind) -> Self {
+        self.method = Method::Update;
+        self.set_exprs.push(SetExpr::Step {
+            col: col.to_owned(),
+            by: by.into_bind(),
+            neg: true,
+        });
+        self
+    }
+```
+
+(`IntoBind` is already imported in `builder.rs` — verify, it backs `update`.)
+
+- [ ] **Step 4: Implement compile side**
+
+In `src/compile.rs`: add `SetExpr` to the `use crate::builder::{…}` import
+(line 8-11). Replace the `Method::Update` arm body (lines 209-229) with:
+
+```rust
+        Method::Update => {
+            if qb.set.is_empty() && qb.set_exprs.is_empty() {
+                return Err(BuildError::EmptyUpdate);
+            }
+            let mut rows: Vec<&(String, Value)> = qb.set.iter().collect();
+            rows.sort_by(|a, b| a.0.cmp(&b.0));
+            ctx.sql.push_str("UPDATE ");
+            ctx.sql.push_str(&table);
+            ctx.sql.push_str(" SET ");
+            for (i, (k, v)) in rows.iter().enumerate() {
+                if i > 0 {
+                    ctx.sql.push_str(", ");
+                }
+                let col = ctx.esc(k);
+                ctx.sql.push_str(&col);
+                ctx.sql.push_str(" = ");
+                ctx.placeholder::<D>(v.clone());
+            }
+            for (i, ex) in qb.set_exprs.iter().enumerate() {
+                if i > 0 || !rows.is_empty() {
+                    ctx.sql.push_str(", ");
+                }
+                match ex {
+                    SetExpr::Raw { col, expr, binds } => {
+                        let col = ctx.esc(col);
+                        ctx.sql.push_str(&col);
+                        ctx.sql.push_str(" = ");
+                        // Verbatim escape hatch (see `set_raw` docs).
+                        ctx.sql.push_str(expr);
+                        ctx.binds.extend(binds.iter().cloned());
+                    }
+                    SetExpr::Step { col, by, neg } => {
+                        let col = ctx.esc(col);
+                        ctx.sql.push_str(&col);
+                        ctx.sql.push_str(" = ");
+                        ctx.sql.push_str(&col);
+                        ctx.sql.push_str(if *neg { " - " } else { " + " });
+                        ctx.placeholder::<D>(by.clone());
+                    }
+                }
+            }
+            write_wheres::<D>(ctx, &qb.wheres)?;
+            write_returning::<D>(ctx, &qb.returning);
+        }
+```
+
+In `src/error.rs`, update the `EmptyUpdate` doc comment (line ~35) to:
+
+```rust
+    /// `update()` with no columns and no `SET` expressions.
+    EmptyUpdate,
+```
+
+Do NOT change the Display string at line 54.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --test set_expr`
+Expected: 8 PASS. Also `cargo test --doc 2>&1 | tail -3` — two new doctests pass.
+
+- [ ] **Step 6: Full suite + fmt + commit**
+
+```bash
+cargo fmt && cargo test --all-features --quiet 2>&1 | tail -5
+git add src/builder.rs src/compile.rs src/error.rs tests/set_expr.rs
+git commit -m "feat: UPDATE expressions — set_raw, increment, decrement"
+```
+Expected: suite green; the pre-existing `empty_update_errs` in
+`tests/build_error.rs` still passes unchanged.
+
+---
+
+### Task 4: `to_sql_pretty()` / `try_to_sql_pretty()`
+
+**Files:**
+- Modify: `src/builder.rs` (two methods after `try_to_sql`, ends ~line 1232; `BuildError` is already in scope there)
+- Test: `tests/pretty.rs` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/pretty.rs`:
+
+```rust
+//! 3.1.0: `to_sql_pretty` / `try_to_sql_pretty`.
+
+use chain_builder::{Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn pg_pretty_multi_bind() {
+    let out = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .where_gt("age", 21i64)
+        .to_sql_pretty();
+    assert_eq!(
+        out,
+        "SELECT \"id\" FROM \"users\" WHERE \"status\" = $1 AND \"age\" > $2\nbinds:\n  $1 = Text(\"active\")\n  $2 = I64(21)"
+    );
+}
+
+#[test]
+fn sqlite_pretty_labels_ordinals() {
+    let out = QueryBuilder::<Sqlite>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .where_gt("age", 21i64)
+        .to_sql_pretty();
+    assert_eq!(
+        out,
+        "SELECT \"id\" FROM \"users\" WHERE \"status\" = ? AND \"age\" > ?\nbinds:\n  ?1 = Text(\"active\")\n  ?2 = I64(21)"
+    );
+}
+
+#[test]
+fn pretty_zero_binds_is_sql_only() {
+    let out = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .to_sql_pretty();
+    assert_eq!(out, "SELECT \"id\" FROM \"users\"");
+}
+
+#[test]
+fn try_pretty_surfaces_same_build_error() {
+    let qb = QueryBuilder::<Postgres>::table("t")
+        .update(std::iter::empty::<(&str, Value)>());
+    assert_eq!(
+        qb.try_to_sql_pretty().unwrap_err(),
+        qb.try_to_sql().unwrap_err()
+    );
+}
+
+#[test]
+#[should_panic(expected = "update() requires at least one column")]
+fn pretty_panic_twin_message_parity() {
+    let _ = QueryBuilder::<Postgres>::table("t")
+        .update(std::iter::empty::<(&str, Value)>())
+        .to_sql_pretty();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `cargo test --test pretty 2>&1 | tail -10`
+Expected: compile error — `no method named 'to_sql_pretty'`
+
+- [ ] **Step 3: Implement**
+
+In `src/builder.rs`, after `try_to_sql` (ends ~line 1232):
+
+```rust
+    /// Render the compiled query as a human-readable string for logs and
+    /// debugging: the SQL, then one indented line per bind.
+    ///
+    /// ```
+    /// use chain_builder::{Postgres, QueryBuilder};
+    /// let qb = QueryBuilder::<Postgres>::table("users")
+    ///     .select(["id"])
+    ///     .where_eq("status", "active");
+    /// assert_eq!(
+    ///     qb.to_sql_pretty(),
+    ///     "SELECT \"id\" FROM \"users\" WHERE \"status\" = $1\nbinds:\n  $1 = Text(\"active\")"
+    /// );
+    /// ```
+    ///
+    /// Bind labels are the dialect placeholder (`$1`, `$2`, … on Postgres);
+    /// dialects whose placeholder is a bare `?` get a 1-based ordinal
+    /// appended for readability (`?1`, `?2`, …) — the SQL itself still uses
+    /// `?`. With zero binds the output is the SQL line only. The output
+    /// format is for humans and is **not** a stability contract.
+    ///
+    /// Panicking twin of [`Self::try_to_sql_pretty`]; the panic message is
+    /// the [`BuildError`]'s `Display` text (same policy as
+    /// [`Self::to_sql`]).
+    pub fn to_sql_pretty(&self) -> String {
+        self.try_to_sql_pretty().unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Fallible twin of [`Self::to_sql_pretty`]; surfaces the same
+    /// [`BuildError`] as [`Self::try_to_sql`].
+    pub fn try_to_sql_pretty(&self) -> Result<String, BuildError> {
+        let (sql, binds) = try_compile(self)?;
+        let mut out = sql;
+        if !binds.is_empty() {
+            out.push_str("\nbinds:");
+            for (i, b) in binds.iter().enumerate() {
+                let mut label = String::new();
+                D::write_placeholder(&mut label, i + 1);
+                if label == "?" {
+                    label.push_str(&(i + 1).to_string());
+                }
+                out.push_str("\n  ");
+                out.push_str(&label);
+                out.push_str(" = ");
+                out.push_str(&format!("{b:?}"));
+            }
+        }
+        Ok(out)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test pretty`
+Expected: 5 PASS. `cargo test --doc 2>&1 | tail -3` — new doctest passes.
+
+- [ ] **Step 5: Full suite + fmt + commit**
+
+```bash
+cargo fmt && cargo test --all-features --quiet 2>&1 | tail -5
+git add src/builder.rs tests/pretty.rs
+git commit -m "feat: to_sql_pretty / try_to_sql_pretty debug helpers"
+```
+
+---
+
+### Task 5: Book + CHANGELOG
+
+**Files:**
+- Modify: `docs/book/src/query/insert-update-delete.md` (UPDATE expressions section)
+- Modify: `docs/book/src/query/where.md` (subquery-in-groups note)
+- Modify: `docs/book/src/cookbook/search.md` (use crate `escape_like`; fix fence bug at lines 92-97)
+- Modify: `docs/book/src/binds.md` (`to_sql_pretty` section)
+- Modify: `CHANGELOG.md` (new `[Unreleased]` section at top)
+
+No code changes in this task. Book snippet policy A applies: snippets are
+` ```rust,ignore ` or ` ```rust,no_run `, NOT compile-tested, and SQL-comment
+output in snippets must byte-match the test assertions from Tasks 1-4.
+
+- [ ] **Step 1: Read the four book pages fully** (they are short) so edits
+  match each page's voice and structure. Read
+  `docs/superpowers/specs/2026-06-10-v3.1-tier1-design.md` for the contracts.
+
+- [ ] **Step 2: `insert-update-delete.md`** — add a section after the
+  existing UPDATE coverage:
+
+```markdown
+## UPDATE expressions: `set_raw`, `increment`, `decrement`
+
+Plain `update()` can only bind values (`SET "col" = $1`). Three companions
+cover computed assignments (3.1.0+). All three switch the builder to UPDATE,
+so `increment` alone is a valid statement:
+
+```rust,ignore
+use chain_builder::{Postgres, QueryBuilder, Value};
+
+let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+    .update([("name", "x")])
+    .increment("views", 1i64)
+    .set_raw("updated_at", "NOW()", vec![])
+    .where_eq("id", 9i64)
+    .to_sql();
+// UPDATE "t" SET "name" = $1, "views" = "views" + $2, "updated_at" = NOW() WHERE "id" = $3
+```
+
+Ordering: the (sorted) `update()` columns render first, then expressions in
+call order. `increment`/`decrement` are fully structured — column escaped,
+amount bound. `set_raw` is the verbatim escape hatch and follows the same
+positional-placeholder contract as `where_raw`: on Postgres hand-write `$N`
+counting all binds accumulated so far (`SET` precedes `WHERE`); on
+MySQL/SQLite use `?`. Duplicate target columns are not detected — the
+database reports them.
+```
+
+- [ ] **Step 3: `where.md`** — in the section covering `and_where`/`or_where`
+  groups, add:
+
+```markdown
+Since 3.1.0 the four subquery predicates are also available **inside**
+groups, with the same contracts (placeholder continuity included):
+
+```rust,ignore
+let (sql, _) = QueryBuilder::<Postgres>::table("users")
+    .select(["id"])
+    .and_where(|g| {
+        g.where_in_subquery(
+            "id",
+            QueryBuilder::<Postgres>::table("ban")
+                .select(["user_id"])
+                .where_eq("k", 7i64),
+        )
+        .where_not_exists(QueryBuilder::<Postgres>::table("audit").select(["1"]))
+    })
+    .to_sql();
+// SELECT "id" FROM "users" WHERE ("id" IN (SELECT "user_id" FROM "ban" WHERE "k" = $1) AND NOT EXISTS (SELECT "1" FROM "audit"))
+```
+```
+
+- [ ] **Step 4: `search.md`** — two changes:
+  1. Replace the local `fn escape_like` definition block (lines ~55-66) with
+     a reference to the crate function: keep the explanatory prose, change
+     the code block to:
+
+```rust,ignore
+use chain_builder::escape_like; // in-crate since 3.1.0
+
+assert_eq!(escape_like("100%_a\\b"), "100\\%\\_a\\\\b");
+```
+
+  2. Fix the fence bug: the prose paragraph "On MySQL, write the escape
+     literal as `ESCAPE '\\'` …" (lines 94-96) currently sits INSIDE the
+     ` ```rust,ignore ` fence opened at line 76. Move the closing ` ``` ` up
+     so the fence ends after the SQL output comment (line 92), leaving the
+     MySQL paragraph as normal prose after the block. Verify any later
+     `escape_like(q)` usages on the page still read correctly (they now
+     refer to the crate function).
+
+- [ ] **Step 5: `binds.md`** — add a short section at the end:
+
+```markdown
+## Inspecting a query: `to_sql_pretty`
+
+For logs and debugging, `to_sql_pretty()` (3.1.0+) renders the SQL plus one
+line per bind. `try_to_sql_pretty()` is the fallible twin and surfaces the
+same `BuildError` as `try_to_sql()`:
+
+```rust,ignore
+println!("{}", qb.to_sql_pretty());
+// SELECT "id" FROM "users" WHERE "status" = $1
+// binds:
+//   $1 = Text("active")
+```
+
+On `?`-placeholder dialects (MySQL/SQLite) the bind labels carry a 1-based
+ordinal for readability (`?1 = …`); the SQL itself still uses bare `?`. The
+output format is for humans — not a stability contract.
+```
+
+- [ ] **Step 6: `CHANGELOG.md`** — insert at the top, above `## [3.0.0]`:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- **Subquery predicates inside `and_where`/`or_where` groups.**
+  `WhereBuilder` gains `where_exists`, `where_not_exists`,
+  `where_in_subquery`, `where_not_in_subquery`, mirroring the `QueryBuilder`
+  methods (same contracts, placeholder continuity included) — closing the
+  group/top-level API asymmetry.
+- **UPDATE expressions.** `set_raw(col, expr, binds)` (verbatim escape
+  hatch, `where_raw` placeholder contract), plus structured
+  `increment(col, by)` / `decrement(col, by)` for atomic counters. All
+  three switch the builder to UPDATE; expressions render after the sorted
+  `update()` columns, in call order. `EmptyUpdate` now fires only when both
+  the column set and the expression list are empty (message unchanged).
+- **`escape_like()`** at the crate root: escapes `\`, `%`, `_` so user
+  input matches literally in `LIKE`/`ILIKE` patterns (promoted from the
+  cookbook recipe; pair with an explicit `ESCAPE` clause for full
+  portability).
+- **`to_sql_pretty()` / `try_to_sql_pretty()`**: human-readable
+  `(sql, binds)` rendering for logs. Output format is not a stability
+  contract. Twin-API policy applies (panicking twin's message is the
+  `BuildError` Display text).
+```
+
+- [ ] **Step 7: Build the book + commit**
+
+```bash
+mdbook build docs/book   # v0.5.3; create-missing=false makes broken SUMMARY targets fail
+git add docs/book/src CHANGELOG.md
+git commit -m "docs: book + changelog for 3.1.0 Tier-1 features"
+```
+Expected: `mdbook build` exits 0.
+
+---
+
+### Task 6: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Formatting + lints**
+
+```bash
+cargo fmt --check
+cargo clippy --all-features --all-targets -- -D warnings
+```
+Expected: both exit 0.
+
+- [ ] **Step 2: Full test matrix**
+
+```bash
+cargo test --all-features 2>&1 | tail -8
+cargo test --features sqlx_postgres,sqlx_sqlite 2>&1 | tail -8
+```
+Expected: all green. Baseline was 227 (all-features) / 214 (publish combo);
+Tasks 1-4 add 20 integration tests (+3, +4, +8, +5) and 4 doctests — report
+the actual new totals.
+
+- [ ] **Step 3: Book build**
+
+```bash
+mdbook build docs/book
+```
+Expected: exit 0.
+
+- [ ] **Step 4: Commit any stragglers** (there should be none — if `git
+  status` is dirty, investigate before committing).

--- a/docs/superpowers/specs/2026-06-10-v3.1-tier1-design.md
+++ b/docs/superpowers/specs/2026-06-10-v3.1-tier1-design.md
@@ -34,6 +34,7 @@ Ship four small, **purely additive** API improvements as 3.1.0:
 New `pub(crate)` field on `QueryBuilder<D>`: `set_exprs: Vec<SetExpr>`, with
 
 ```rust
+#[derive(Debug, Clone, PartialEq)]   // QueryBuilder derives these; field type must too
 pub(crate) enum SetExpr {
     /// Verbatim RHS escape hatch: `"col" = <expr>` with its own binds.
     Raw { col: String, expr: String, binds: Vec<Value> },
@@ -63,7 +64,12 @@ pub fn decrement(mut self, col: &str, by: impl IntoBind) -> Self
   then `set_exprs` in insertion order, comma-joined. This mirrors the existing
   `order_by_raw`/`group_by_raw` convention (raw appended after structured).
 - `EmptyUpdate` check becomes: error iff `set.is_empty() && set_exprs.is_empty()`
-  (Update method only).
+  (Update method only). **Same variant, same Display text**
+  (`"update() requires at least one column"`, `src/error.rs:54`) — no new
+  `BuildError` variant; the byte-exact assertion in `tests/build_error.rs:64`
+  and the panic-twin tests stay valid. The variant's doc comment
+  (`src/error.rs:35`, "update() with no columns") gets a one-line tweak to
+  mention expressions.
 - `set_raw`: `col` IS identifier-escaped; `expr` is emitted **verbatim** with
   `binds` appended — same positional-placeholder contract and rustdoc warning
   as `where_raw` (`src/where_.rs:301-310`): Postgres callers must write `$N`
@@ -119,12 +125,18 @@ pub fn escape_like(input: &str) -> String
 - Behavior byte-identical to the cookbook recipe
   (`docs/book/src/cookbook/search.md:57`): escapes backslash first, then `%`
   and `_`, with `\` as the escape character.
-  Pinned: `escape_like("100%_a\\b") == "100\\%\\_a\\\\b"`.
+  Pinned cookbook assertion (the book blocks are `rust,ignore`, never
+  executed — this becomes a real unit test):
+  `escape_like("100%_a\\b") == "100\\%\\_a\\\\b"`.
 - Rustdoc carries the cookbook's caveat: for fully portable literal matching,
   pair with an explicit `ESCAPE '\'` clause (`where_raw` form); MySQL string
   literals need `ESCAPE '\\'`.
 - `docs/book/src/cookbook/search.md` is updated to call the crate function
-  instead of defining its own, keeping the ESCAPE-clause discussion.
+  instead of defining its own, keeping the ESCAPE-clause discussion. While
+  editing, fix the pre-existing fence bug at `search.md:92-97`: the prose
+  paragraph "On MySQL, write the escape literal as `ESCAPE '\\'` …" sits
+  inside the ` ```rust,ignore ` fence opened at `:76` — move it outside the
+  fence.
 
 ## Feature 4 — `to_sql_pretty()` / `try_to_sql_pretty()`
 
@@ -145,9 +157,13 @@ binds:
 
 - One line per bind, indented two spaces, `<label> = <Value's Debug>`.
   `Value` already derives `Debug` (`src/value.rs:12`).
-- Label: produced via `D::write_placeholder` semantics — Postgres `$N`;
-  MySQL/SQLite render `?N` (1-based ordinal appended for readability; the SQL
-  itself still uses bare `?`).
+- Label mechanism (explicit, to avoid divergent readings): write the
+  placeholder for ordinal `n` into a scratch `String` via
+  `D::write_placeholder`; if the result does **not** encode the ordinal
+  (i.e. it is exactly `"?"` — MySQL/SQLite ignore `n`), append the 1-based
+  ordinal. Result: Postgres `$1` (never `$11`), MySQL/SQLite `?1`. The SQL
+  line itself still uses whatever the compiler emitted (bare `?` for those
+  dialects).
 - Zero binds → the SQL line only; no `binds:` section.
 - `to_sql_pretty` delegates to `try_to_sql_pretty` and panics with the same
   Display string on `BuildError`, matching the twin-API policy recorded in
@@ -161,6 +177,8 @@ binds:
 - `src/compile.rs` — `Method::Update` arm: render `set_exprs` after structured
   set; adjust `EmptyUpdate` condition. No predicate-writer changes.
 - `src/lib.rs` (+ optional new small module) — `escape_like` export.
+- `src/error.rs` — one-line doc tweak on the `EmptyUpdate` variant (mention
+  expressions); Display text unchanged.
 - `tests/` — new/extended test files per feature (byte-exact SQL assertions
   across Postgres + MySQL + SQLite where dialect-relevant).
 - `docs/book/src/query/insert-update-delete.md` — UPDATE expressions section.

--- a/docs/superpowers/specs/2026-06-10-v3.1-tier1-design.md
+++ b/docs/superpowers/specs/2026-06-10-v3.1-tier1-design.md
@@ -1,0 +1,228 @@
+# chain-builder 3.1.0 — Tier 1 features (design)
+
+Date: 2026-06-10
+Status: approved in-session (interactive brainstorm); pipeline continues autonomously.
+Baseline: `main` after v3.0.0 (227 tests all-features; 4 doctests run, 1 ignored).
+
+## Goal
+
+Ship four small, **purely additive** API improvements as 3.1.0:
+
+1. **UPDATE expressions** — `set_raw`, `increment`, `decrement` on `QueryBuilder`.
+2. **Subquery predicates on `WhereBuilder`** — close the API asymmetry: the four
+   subquery methods that exist on `QueryBuilder` become available inside
+   `and_where`/`or_where` groups.
+3. **`escape_like()`** — promote the cookbook's LIKE-escaping recipe into the crate.
+4. **`to_sql_pretty()` / `try_to_sql_pretty()`** — human-readable (sql, binds)
+   rendering for logs and debugging.
+
+## Non-goals (explicitly out of scope)
+
+- No breaking changes. No MSRV change. No new feature flags.
+- No auto-renumbering of `$N` placeholders in raw fragments (Tier 3; raw stays
+  verbatim).
+- No INSERT…SELECT, `from_subquery`, pg `= ANY($1)` array binds, structured
+  HAVING, `order_by_checked` (Tier 2 — separate effort).
+- No duplicate-SET-column detection (documented as caller responsibility; a
+  deferred `BuildError` can be added later if demand shows up).
+- No new mdBook pages; only edits to existing pages. `SUMMARY.md` unchanged.
+
+## Feature 1 — UPDATE expressions
+
+### Storage
+
+New `pub(crate)` field on `QueryBuilder<D>`: `set_exprs: Vec<SetExpr>`, with
+
+```rust
+pub(crate) enum SetExpr {
+    /// Verbatim RHS escape hatch: `"col" = <expr>` with its own binds.
+    Raw { col: String, expr: String, binds: Vec<Value> },
+    /// Structured `"col" = "col" + $N` (neg → `-`).
+    Step { col: String, by: Value, neg: bool },
+}
+```
+
+The existing `set: Vec<(String, Value)>` field is **not touched** — it is shared
+with the INSERT path and is sorted by column name at compile time
+(`src/compile.rs` `Method::Update` arm); changing it risks both paths.
+
+### API (on `QueryBuilder<D>`, in `src/builder.rs` near `update`)
+
+```rust
+pub fn set_raw(mut self, col: &str, expr: &str, binds: Vec<Value>) -> Self
+pub fn increment(mut self, col: &str, by: impl IntoBind) -> Self
+pub fn decrement(mut self, col: &str, by: impl IntoBind) -> Self
+```
+
+### Semantics
+
+- All three set `self.method = Method::Update`, exactly like `update()` /
+  `delete()` (the crate's existing last-call-wins convention). Consequently
+  `qb.increment("views", 1)` alone is a valid UPDATE — no `update([])` needed.
+- **SET ordering**: structured `set` pairs first (sorted by column, unchanged),
+  then `set_exprs` in insertion order, comma-joined. This mirrors the existing
+  `order_by_raw`/`group_by_raw` convention (raw appended after structured).
+- `EmptyUpdate` check becomes: error iff `set.is_empty() && set_exprs.is_empty()`
+  (Update method only).
+- `set_raw`: `col` IS identifier-escaped; `expr` is emitted **verbatim** with
+  `binds` appended — same positional-placeholder contract and rustdoc warning
+  as `where_raw` (`src/where_.rs:301-310`): Postgres callers must write `$N`
+  matching `binds already accumulated + 1`; MySQL/SQLite use `?`. Note for SET
+  the accumulated count at that point is: all structured SET binds + binds of
+  earlier `set_exprs` (SET precedes WHERE in an UPDATE statement).
+- `increment`/`decrement`: fully structured. Column escaped, value bound via
+  the normal placeholder machinery: `"views" = "views" + $2` / `… - $2`.
+- If the method is later switched away from Update (e.g. `.set_raw(...).insert(...)`),
+  `set_exprs` is **silently ignored** — consistent with how leftover `set`
+  state is ignored today when the method changes. Documented in rustdoc.
+- Duplicate column across `set` and `set_exprs` (or within `set_exprs`): not
+  detected; emitted as-is; the database reports it. Documented in rustdoc.
+
+### Example
+
+```rust
+qb.update([("name", v("x"))])
+  .increment("views", 1)
+  .set_raw("updated_at", "NOW()", vec![])
+// UPDATE "t" SET "name" = $1, "views" = "views" + $2, "updated_at" = NOW() WHERE …
+```
+
+## Feature 2 — Subquery predicates on `WhereBuilder`
+
+Add four methods to `WhereBuilder<D>` (`src/where_.rs`) mirroring the
+`QueryBuilder` versions at `src/builder.rs:657-693` with identical signatures:
+
+```rust
+pub fn where_exists(self, sub: QueryBuilder<D>) -> Self
+pub fn where_not_exists(self, sub: QueryBuilder<D>) -> Self
+pub fn where_in_subquery(self, col: &str, sub: QueryBuilder<D>) -> Self
+pub fn where_not_in_subquery(self, col: &str, sub: QueryBuilder<D>) -> Self
+```
+
+They push the **existing** `Predicate::Exists` / `Predicate::InSubquery`
+variants into `self.preds`. The compiler already renders every `Predicate`
+variant inside `Predicate::Group` through the same predicate writer (including
+placeholder continuity), so **no `src/compile.rs` change is required** — tests
+must prove this, not assume it. Rustdoc on each method links to the
+`QueryBuilder` counterpart for the full contract.
+
+## Feature 3 — `escape_like()`
+
+```rust
+/// Escape `\`, `%`, and `_` so user input matches literally inside a LIKE
+/// pattern. The caller still wraps the result in `%…%` / `…%` as needed.
+pub fn escape_like(input: &str) -> String
+```
+
+- Lives at crate root (exported from `src/lib.rs`; implementation may sit in a
+  small `src/like.rs` or alongside an existing module — implementer's choice).
+- Behavior byte-identical to the cookbook recipe
+  (`docs/book/src/cookbook/search.md:57`): escapes backslash first, then `%`
+  and `_`, with `\` as the escape character.
+  Pinned: `escape_like("100%_a\\b") == "100\\%\\_a\\\\b"`.
+- Rustdoc carries the cookbook's caveat: for fully portable literal matching,
+  pair with an explicit `ESCAPE '\'` clause (`where_raw` form); MySQL string
+  literals need `ESCAPE '\\'`.
+- `docs/book/src/cookbook/search.md` is updated to call the crate function
+  instead of defining its own, keeping the ESCAPE-clause discussion.
+
+## Feature 4 — `to_sql_pretty()` / `try_to_sql_pretty()`
+
+On `QueryBuilder<D>` (`src/builder.rs`, near `to_sql`/`try_to_sql`):
+
+```rust
+pub fn to_sql_pretty(&self) -> String                          // panics like to_sql
+pub fn try_to_sql_pretty(&self) -> Result<String, BuildError>  // twin (3.0 policy)
+```
+
+Output format (no trailing newline):
+
+```text
+SELECT "id" FROM "users" WHERE "status" = $1
+binds:
+  $1 = Text("active")
+```
+
+- One line per bind, indented two spaces, `<label> = <Value's Debug>`.
+  `Value` already derives `Debug` (`src/value.rs:12`).
+- Label: produced via `D::write_placeholder` semantics — Postgres `$N`;
+  MySQL/SQLite render `?N` (1-based ordinal appended for readability; the SQL
+  itself still uses bare `?`).
+- Zero binds → the SQL line only; no `binds:` section.
+- `to_sql_pretty` delegates to `try_to_sql_pretty` and panics with the same
+  Display string on `BuildError`, matching the twin-API policy recorded in
+  CHANGELOG 3.0.0.
+
+## File structure (expected touch set)
+
+- `src/builder.rs` — `set_exprs` field, `set_raw`/`increment`/`decrement`,
+  `to_sql_pretty`/`try_to_sql_pretty`.
+- `src/where_.rs` — four subquery methods on `WhereBuilder`.
+- `src/compile.rs` — `Method::Update` arm: render `set_exprs` after structured
+  set; adjust `EmptyUpdate` condition. No predicate-writer changes.
+- `src/lib.rs` (+ optional new small module) — `escape_like` export.
+- `tests/` — new/extended test files per feature (byte-exact SQL assertions
+  across Postgres + MySQL + SQLite where dialect-relevant).
+- `docs/book/src/query/insert-update-delete.md` — UPDATE expressions section.
+- `docs/book/src/query/where.md` — subquery-in-groups example.
+- `docs/book/src/cookbook/search.md` — switch to crate `escape_like`.
+- `docs/book/src/binds.md` — `to_sql_pretty` section.
+- `CHANGELOG.md` — `[Unreleased]` section (renamed to `[3.1.0]` at release).
+
+## Tests (acceptance-level)
+
+All TDD: failing test first, then implementation. Byte-exact SQL assertions.
+
+1. UPDATE expressions:
+   - `update + increment + set_raw` → exact SQL + binds order (pg `$N` continuity
+     into WHERE), MySQL/SQLite `?` variants.
+   - `increment` alone (no `update()` call) compiles to a valid UPDATE.
+   - `decrement` emits `-`.
+   - `set_raw` with own binds: positions correct after structured set binds.
+   - Empty: `update([])` with no exprs → `BuildError::EmptyUpdate` via
+     `try_to_sql`; panic twin message parity via `should_panic(expected=…)`.
+   - Update with **only** exprs and empty `set` → OK (no EmptyUpdate).
+2. WhereBuilder subqueries:
+   - `and_where(|w| w.where_exists(sub))` and `or_where(|w| w.where_in_subquery(…))`
+     → exact SQL incl. parens and placeholder continuity across outer binds,
+     sub-binds, and following predicates.
+   - NOT variants.
+3. `escape_like`: the pinned cookbook assertion + empty string + no-op input.
+4. `to_sql_pretty`:
+   - pg: multi-bind query → exact full string (SQL line + `binds:` + `$N` lines).
+   - SQLite or MySQL: `?N` labels.
+   - Zero binds → SQL only.
+   - `try_to_sql_pretty` on a `having()` misuse → same `BuildError` as
+     `try_to_sql`; panic twin parity test.
+
+Baseline: existing 227 all-features tests stay green; publish.yml combo
+(`sqlx_postgres,sqlx_sqlite`) stays green (214 at baseline).
+
+## Acceptance criteria
+
+- [ ] All new public APIs have rustdoc with examples; raw escape hatches carry
+      the positional-placeholder warning.
+- [ ] All tests above pass; full suite green all-features and publish-combo.
+- [ ] `cargo fmt --check` + `clippy` clean (ci.yml gates).
+- [ ] Book pages updated per touch set; book builds (`mdbook build docs/book`,
+      v0.5.3, `create-missing = false`).
+- [ ] CHANGELOG `[Unreleased]` lists all four features as Added.
+- [ ] No public API removed or changed (additive only; semver-minor).
+
+## Known limitations
+
+- `set_raw` inherits the verbatim `$N` contract — wrong numbers produce
+  malformed SQL at runtime, by design (consistent with every other raw hatch).
+- `to_sql_pretty` is for humans/logs; output format is NOT a stability
+  contract (rustdoc says so explicitly).
+- Duplicate SET columns surface as database errors, not build errors.
+
+## Open questions resolved during design
+
+- **Why not unify `set` into one enum?** `set` is shared with INSERT and
+  sorted at compile; refactoring it risks two paths for zero user-visible gain.
+- **Why do `set_raw`/`increment` switch the method?** Matches the existing
+  last-call-wins convention (`delete()` after `insert()` already flips
+  silently). A deferred error would be *less* consistent here.
+- **Why `?N` labels in pretty output for MySQL/SQLite?** Bare `?` lines would
+  be ambiguous with multiple binds; the ordinal is a readability label only.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -228,6 +228,33 @@ pub enum SelectExpr {
     },
 }
 
+/// A structured or raw `SET` expression for UPDATE. Backs
+/// [`QueryBuilder::set_raw`] / [`QueryBuilder::increment`] /
+/// [`QueryBuilder::decrement`]. Rendered after the (sorted) structured
+/// `update()` columns, in call order.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum SetExpr {
+    /// `{esc col} = {expr verbatim}` with its own binds (NOT escaped or
+    /// renumbered — the `where_raw` contract).
+    Raw {
+        /// Column identifier; escaped in compile.rs.
+        col: String,
+        /// Verbatim RHS expression.
+        expr: String,
+        /// Binds appended to the running bind list in order.
+        binds: Vec<Value>,
+    },
+    /// `{esc col} = {esc col} {+|-} {placeholder}` — structured step.
+    Step {
+        /// Column identifier; escaped in compile.rs.
+        col: String,
+        /// The step amount, bound via the normal placeholder machinery.
+        by: Value,
+        /// `false` → `+` (increment); `true` → `-` (decrement).
+        neg: bool,
+    },
+}
+
 /// The strength of a row-locking clause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LockStrength {
@@ -301,6 +328,9 @@ pub struct QueryBuilder<D: Dialect> {
     pub(crate) wheres: Vec<Predicate<D>>,
     pub(crate) method: Method,
     pub(crate) set: Vec<(String, Value)>,
+    /// UPDATE `SET` expressions, rendered after the sorted `set` pairs in
+    /// call order. Backs `set_raw`/`increment`/`decrement`.
+    pub(crate) set_exprs: Vec<SetExpr>,
     /// Multi-row `INSERT` rows (empty unless `insert_many` was used). Each row is
     /// a `(column, value)` list; columns come from the first row's sorted keys.
     pub(crate) insert_rows: Vec<Vec<(String, Value)>>,
@@ -346,6 +376,7 @@ impl<D: Dialect> QueryBuilder<D> {
             wheres: Vec::new(),
             method: Method::Select,
             set: Vec::new(),
+            set_exprs: Vec::new(),
             insert_rows: Vec::new(),
             joins: Vec::new(),
             groups: Vec::new(),
@@ -766,6 +797,77 @@ impl<D: Dialect> QueryBuilder<D> {
             .into_iter()
             .map(|(k, v)| (k.as_ref().to_owned(), v.into_bind()))
             .collect();
+        self
+    }
+
+    /// Set a column to a **verbatim** SQL expression — the UPDATE escape
+    /// hatch. Switches the builder to UPDATE, like [`Self::update`] (and
+    /// like every method-selecting call, last one wins: switching away from
+    /// UPDATE afterwards leaves the expressions ignored).
+    ///
+    /// `col` is identifier-escaped; `expr` is emitted verbatim with `binds`
+    /// appended. Expressions render after the (sorted) structured
+    /// [`Self::update`] columns, in call order. Duplicate target columns are
+    /// not detected — the database reports them.
+    ///
+    /// # Warning: positional placeholder contract
+    ///
+    /// `expr` is NOT escaped or renumbered. For **Postgres**, hand-write
+    /// `$N` matching the actual bind position — `SET` precedes `WHERE`, so
+    /// that is `structured SET binds + binds of earlier expressions + 1`,
+    /// `+2`, … For MySQL/SQLite use `?`. A wrong `$N` produces a malformed
+    /// query.
+    ///
+    /// ```
+    /// use chain_builder::{Postgres, QueryBuilder, Value};
+    /// let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+    ///     .update([("name", "x")])
+    ///     .set_raw("updated_at", "NOW()", vec![])
+    ///     .to_sql();
+    /// assert_eq!(sql, r#"UPDATE "t" SET "name" = $1, "updated_at" = NOW()"#);
+    /// assert_eq!(binds, vec![Value::Text("x".into())]);
+    /// ```
+    pub fn set_raw(mut self, col: &str, expr: &str, binds: Vec<Value>) -> Self {
+        self.method = Method::Update;
+        self.set_exprs.push(SetExpr::Raw {
+            col: col.to_owned(),
+            expr: expr.to_owned(),
+            binds,
+        });
+        self
+    }
+
+    /// `col = col + value` — atomic counter increment. Structured (column
+    /// escaped, value bound); switches the builder to UPDATE, so
+    /// `qb.increment("views", 1)` alone is a valid UPDATE.
+    ///
+    /// ```
+    /// use chain_builder::{Postgres, QueryBuilder, Value};
+    /// let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+    ///     .increment("views", 1i64)
+    ///     .to_sql();
+    /// assert_eq!(sql, r#"UPDATE "t" SET "views" = "views" + $1"#);
+    /// assert_eq!(binds, vec![Value::I64(1)]);
+    /// ```
+    pub fn increment(mut self, col: &str, by: impl IntoBind) -> Self {
+        self.method = Method::Update;
+        self.set_exprs.push(SetExpr::Step {
+            col: col.to_owned(),
+            by: by.into_bind(),
+            neg: false,
+        });
+        self
+    }
+
+    /// `col = col - value` — atomic counter decrement. See
+    /// [`Self::increment`].
+    pub fn decrement(mut self, col: &str, by: impl IntoBind) -> Self {
+        self.method = Method::Update;
+        self.set_exprs.push(SetExpr::Step {
+            col: col.to_owned(),
+            by: by.into_bind(),
+            neg: true,
+        });
         self
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -813,10 +813,11 @@ impl<D: Dialect> QueryBuilder<D> {
     /// # Warning: positional placeholder contract
     ///
     /// `expr` is NOT escaped or renumbered. For **Postgres**, hand-write
-    /// `$N` matching the actual bind position — `SET` precedes `WHERE`, so
-    /// that is `structured SET binds + binds of earlier expressions + 1`,
-    /// `+2`, … For MySQL/SQLite use `?`. A wrong `$N` produces a malformed
-    /// query.
+    /// `$N` matching the actual bind position at the point this expression
+    /// is reached — `SET` precedes `WHERE`, so that is `(number of
+    /// structured SET binds) + (binds of all earlier expressions, counting
+    /// 1 per preceding `increment`/`decrement`) + 1`, `+2`, … For
+    /// MySQL/SQLite use `?`. A wrong `$N` produces a malformed query.
     ///
     /// ```
     /// use chain_builder::{Postgres, QueryBuilder, Value};

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1353,6 +1353,11 @@ impl<D: Dialect> QueryBuilder<D> {
     /// `?`. With zero binds the output is the SQL line only. The output
     /// format is for humans and is **not** a stability contract.
     ///
+    /// # Warning
+    ///
+    /// The output includes the **literal bind values**. Do not log it if
+    /// any bind may contain sensitive data (passwords, tokens, PII).
+    ///
     /// Panicking twin of [`Self::try_to_sql_pretty`]; the panic message is
     /// the [`BuildError`]'s `Display` text (same policy as
     /// [`Self::to_sql`]).
@@ -1361,22 +1366,26 @@ impl<D: Dialect> QueryBuilder<D> {
     }
 
     /// Fallible twin of [`Self::to_sql_pretty`]; surfaces the same
-    /// [`BuildError`] as [`Self::try_to_sql`].
+    /// [`BuildError`] as [`Self::try_to_sql`]. The same sensitive-data
+    /// warning applies.
     pub fn try_to_sql_pretty(&self) -> Result<String, BuildError> {
+        use std::fmt::Write as _;
         let (sql, binds) = try_compile(self)?;
         let mut out = sql;
         if !binds.is_empty() {
             out.push_str("\nbinds:");
+            let mut label = String::with_capacity(4);
             for (i, b) in binds.iter().enumerate() {
-                let mut label = String::new();
+                label.clear();
                 D::write_placeholder(&mut label, i + 1);
                 if label == "?" {
-                    label.push_str(&(i + 1).to_string());
+                    // Infallible for String.
+                    let _ = write!(label, "{}", i + 1);
                 }
                 out.push_str("\n  ");
                 out.push_str(&label);
                 out.push_str(" = ");
-                out.push_str(&format!("{b:?}"));
+                let _ = write!(out, "{b:?}");
             }
         }
         Ok(out)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1332,4 +1332,53 @@ impl<D: Dialect> QueryBuilder<D> {
     pub fn try_to_sql(&self) -> Result<(String, Vec<Value>), BuildError> {
         try_compile(self)
     }
+
+    /// Render the compiled query as a human-readable string for logs and
+    /// debugging: the SQL, then one indented line per bind.
+    ///
+    /// ```
+    /// use chain_builder::{Postgres, QueryBuilder};
+    /// let qb = QueryBuilder::<Postgres>::table("users")
+    ///     .select(["id"])
+    ///     .where_eq("status", "active");
+    /// assert_eq!(
+    ///     qb.to_sql_pretty(),
+    ///     "SELECT \"id\" FROM \"users\" WHERE \"status\" = $1\nbinds:\n  $1 = Text(\"active\")"
+    /// );
+    /// ```
+    ///
+    /// Bind labels are the dialect placeholder (`$1`, `$2`, … on Postgres);
+    /// dialects whose placeholder is a bare `?` get a 1-based ordinal
+    /// appended for readability (`?1`, `?2`, …) — the SQL itself still uses
+    /// `?`. With zero binds the output is the SQL line only. The output
+    /// format is for humans and is **not** a stability contract.
+    ///
+    /// Panicking twin of [`Self::try_to_sql_pretty`]; the panic message is
+    /// the [`BuildError`]'s `Display` text (same policy as
+    /// [`Self::to_sql`]).
+    pub fn to_sql_pretty(&self) -> String {
+        self.try_to_sql_pretty().unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Fallible twin of [`Self::to_sql_pretty`]; surfaces the same
+    /// [`BuildError`] as [`Self::try_to_sql`].
+    pub fn try_to_sql_pretty(&self) -> Result<String, BuildError> {
+        let (sql, binds) = try_compile(self)?;
+        let mut out = sql;
+        if !binds.is_empty() {
+            out.push_str("\nbinds:");
+            for (i, b) in binds.iter().enumerate() {
+                let mut label = String::new();
+                D::write_placeholder(&mut label, i + 1);
+                if label == "?" {
+                    label.push_str(&(i + 1).to_string());
+                }
+                out.push_str("\n  ");
+                out.push_str(&label);
+                out.push_str(" = ");
+                out.push_str(&format!("{b:?}"));
+            }
+        }
+        Ok(out)
+    }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -7,7 +7,7 @@
 
 use crate::builder::{
     ConflictAction, Cte, Having, Join, JoinCond, JoinKind, Lock, LockStrength, LockWait, Method,
-    Order, QueryBuilder, SelectExpr,
+    Order, QueryBuilder, SelectExpr, SetExpr,
 };
 use crate::dialect::{Dialect, UpsertStyle};
 use crate::error::BuildError;
@@ -207,7 +207,7 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) -> Result<(), B
             write_returning::<D>(ctx, &qb.returning);
         }
         Method::Update => {
-            if qb.set.is_empty() {
+            if qb.set.is_empty() && qb.set_exprs.is_empty() {
                 return Err(BuildError::EmptyUpdate);
             }
             let mut rows: Vec<&(String, Value)> = qb.set.iter().collect();
@@ -223,6 +223,29 @@ fn compile_into<D: Dialect>(ctx: &mut Ctx, qb: &QueryBuilder<D>) -> Result<(), B
                 ctx.sql.push_str(&col);
                 ctx.sql.push_str(" = ");
                 ctx.placeholder::<D>(v.clone());
+            }
+            for (i, ex) in qb.set_exprs.iter().enumerate() {
+                if i > 0 || !rows.is_empty() {
+                    ctx.sql.push_str(", ");
+                }
+                match ex {
+                    SetExpr::Raw { col, expr, binds } => {
+                        let col = ctx.esc(col);
+                        ctx.sql.push_str(&col);
+                        ctx.sql.push_str(" = ");
+                        // Verbatim escape hatch (see `set_raw` docs).
+                        ctx.sql.push_str(expr);
+                        ctx.binds.extend(binds.iter().cloned());
+                    }
+                    SetExpr::Step { col, by, neg } => {
+                        let col = ctx.esc(col);
+                        ctx.sql.push_str(&col);
+                        ctx.sql.push_str(" = ");
+                        ctx.sql.push_str(&col);
+                        ctx.sql.push_str(if *neg { " - " } else { " + " });
+                        ctx.placeholder::<D>(by.clone());
+                    }
+                }
             }
             write_wheres::<D>(ctx, &qb.wheres)?;
             write_returning::<D>(ctx, &qb.returning);

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ pub enum BuildError {
     DistinctOnRequiresPostgres,
     /// `insert()` with no columns.
     EmptyInsert,
-    /// `update()` with no columns.
+    /// `update()` with no columns and no `SET` expressions.
     EmptyUpdate,
     /// `offset(...)` without `limit(...)`.
     OffsetWithoutLimit,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod compile;
 pub mod dialect;
 pub mod error;
 pub mod ident;
+pub mod like;
 pub mod value;
 pub mod where_;
 
@@ -55,6 +56,7 @@ pub use builder::{
 pub use compile::{compile, try_compile};
 pub use dialect::{Dialect, MySql, Postgres, Sqlite, UpsertStyle};
 pub use error::{BuildError, Error};
+pub use like::escape_like;
 pub use value::{IntoBind, Value};
 pub use where_::{Conj, Predicate, WhereBuilder};
 

--- a/src/like.rs
+++ b/src/like.rs
@@ -2,7 +2,8 @@
 
 /// Escape `\`, `%`, and `_` so user input matches **literally** inside a
 /// `LIKE`/`ILIKE` pattern. The caller still wraps the result in `%…%` /
-/// `…%` as needed.
+/// `…%` as needed — and the result stays a **bind value** (pass it through
+/// `where_like`/a placeholder as usual; never splice it into the SQL text).
 ///
 /// Backslash is escaped first (order matters), then `%` and `_`:
 ///
@@ -20,6 +21,10 @@
 /// matching, pair the escaped pattern with an explicit `ESCAPE '\'` clause
 /// via `where_raw` (on MySQL write the literal as `ESCAPE '\\'`). See the
 /// search-pattern chapter of the book for the full recipe.
+///
+/// Covers the metacharacters of the supported dialects (Postgres, MySQL,
+/// SQLite). `[` — a `LIKE` metacharacter on SQL Server only — is **not**
+/// escaped.
 pub fn escape_like(input: &str) -> String {
     input
         .replace('\\', "\\\\")

--- a/src/like.rs
+++ b/src/like.rs
@@ -1,0 +1,28 @@
+//! `LIKE`-pattern escaping helper.
+
+/// Escape `\`, `%`, and `_` so user input matches **literally** inside a
+/// `LIKE`/`ILIKE` pattern. The caller still wraps the result in `%…%` /
+/// `…%` as needed.
+///
+/// Backslash is escaped first (order matters), then `%` and `_`:
+///
+/// ```
+/// use chain_builder::escape_like;
+/// assert_eq!(escape_like("100%_a\\b"), "100\\%\\_a\\\\b");
+/// assert_eq!(format!("%{}%", escape_like("50%")), "%50\\%%");
+/// ```
+///
+/// # Portability caveat
+///
+/// What `\` means inside a `LIKE` pattern is dialect-defined: Postgres and
+/// MySQL treat backslash as the default escape character, but **SQLite has
+/// no default escape character at all**. For fully portable literal
+/// matching, pair the escaped pattern with an explicit `ESCAPE '\'` clause
+/// via `where_raw` (on MySQL write the literal as `ESCAPE '\\'`). See the
+/// search-pattern chapter of the book for the full recipe.
+pub fn escape_like(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}

--- a/src/where_.rs
+++ b/src/where_.rs
@@ -327,4 +327,47 @@ impl<D: Dialect> WhereBuilder<D> {
         });
         self
     }
+
+    /// `EXISTS (subquery)` inside this group. Mirrors
+    /// [`QueryBuilder::where_exists`](crate::QueryBuilder::where_exists) —
+    /// same contract, including placeholder continuity into the sub-query.
+    pub fn where_exists(mut self, sub: QueryBuilder<D>) -> Self {
+        self.preds.push(Predicate::Exists {
+            neg: false,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `NOT EXISTS (subquery)` inside this group. See
+    /// [`QueryBuilder::where_not_exists`](crate::QueryBuilder::where_not_exists).
+    pub fn where_not_exists(mut self, sub: QueryBuilder<D>) -> Self {
+        self.preds.push(Predicate::Exists {
+            neg: true,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `col IN (subquery)` inside this group. Mirrors
+    /// [`QueryBuilder::where_in_subquery`](crate::QueryBuilder::where_in_subquery).
+    pub fn where_in_subquery(mut self, col: &str, sub: QueryBuilder<D>) -> Self {
+        self.preds.push(Predicate::InSubquery {
+            col: col.to_owned(),
+            neg: false,
+            sub: Box::new(sub),
+        });
+        self
+    }
+
+    /// `col NOT IN (subquery)` inside this group. See
+    /// [`QueryBuilder::where_not_in_subquery`](crate::QueryBuilder::where_not_in_subquery).
+    pub fn where_not_in_subquery(mut self, col: &str, sub: QueryBuilder<D>) -> Self {
+        self.preds.push(Predicate::InSubquery {
+            col: col.to_owned(),
+            neg: true,
+            sub: Box::new(sub),
+        });
+        self
+    }
 }

--- a/src/where_.rs
+++ b/src/where_.rs
@@ -339,8 +339,10 @@ impl<D: Dialect> WhereBuilder<D> {
         self
     }
 
-    /// `NOT EXISTS (subquery)` inside this group. See
-    /// [`QueryBuilder::where_not_exists`](crate::QueryBuilder::where_not_exists).
+    /// `NOT EXISTS (subquery)` inside this group. Mirrors
+    /// [`QueryBuilder::where_not_exists`](crate::QueryBuilder::where_not_exists) —
+    /// same contract as [`Self::where_exists`], including placeholder
+    /// continuity into the sub-query.
     pub fn where_not_exists(mut self, sub: QueryBuilder<D>) -> Self {
         self.preds.push(Predicate::Exists {
             neg: true,
@@ -360,8 +362,10 @@ impl<D: Dialect> WhereBuilder<D> {
         self
     }
 
-    /// `col NOT IN (subquery)` inside this group. See
-    /// [`QueryBuilder::where_not_in_subquery`](crate::QueryBuilder::where_not_in_subquery).
+    /// `col NOT IN (subquery)` inside this group. Mirrors
+    /// [`QueryBuilder::where_not_in_subquery`](crate::QueryBuilder::where_not_in_subquery) —
+    /// same contract as [`Self::where_in_subquery`], including placeholder
+    /// continuity into the sub-query.
     pub fn where_not_in_subquery(mut self, col: &str, sub: QueryBuilder<D>) -> Self {
         self.preds.push(Predicate::InSubquery {
             col: col.to_owned(),

--- a/tests/escape_like.rs
+++ b/tests/escape_like.rs
@@ -1,0 +1,26 @@
+//! 3.1.0: `escape_like` — LIKE-pattern metacharacter escaping.
+
+use chain_builder::escape_like;
+
+#[test]
+fn pinned_cookbook_assertion() {
+    // Byte-identical to the recipe in docs/book/src/cookbook/search.md.
+    assert_eq!(escape_like("100%_a\\b"), "100\\%\\_a\\\\b");
+}
+
+#[test]
+fn empty_input_is_empty() {
+    assert_eq!(escape_like(""), "");
+}
+
+#[test]
+fn input_without_metachars_is_unchanged() {
+    assert_eq!(escape_like("hello world"), "hello world");
+}
+
+#[test]
+fn each_metachar_escaped() {
+    assert_eq!(escape_like("%"), "\\%");
+    assert_eq!(escape_like("_"), "\\_");
+    assert_eq!(escape_like("\\"), "\\\\");
+}

--- a/tests/escape_like.rs
+++ b/tests/escape_like.rs
@@ -24,3 +24,10 @@ fn each_metachar_escaped() {
     assert_eq!(escape_like("_"), "\\_");
     assert_eq!(escape_like("\\"), "\\\\");
 }
+
+#[test]
+fn adjacent_metachars_validate_escape_ordering() {
+    // `\%_` must become `\\` + `\%` + `\_` — a wrong replace order would
+    // double-escape the backslashes produced for `%`/`_`.
+    assert_eq!(escape_like("\\%_"), "\\\\\\%\\_");
+}

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -1,6 +1,6 @@
 //! 3.1.0: `to_sql_pretty` / `try_to_sql_pretty`.
 
-use chain_builder::{Postgres, QueryBuilder, Sqlite, Value};
+use chain_builder::{MySql, Postgres, QueryBuilder, Sqlite, Value};
 
 #[test]
 fn pg_pretty_multi_bind() {
@@ -51,4 +51,16 @@ fn pretty_panic_twin_message_parity() {
     let _ = QueryBuilder::<Postgres>::table("t")
         .update(std::iter::empty::<(&str, Value)>())
         .to_sql_pretty();
+}
+
+#[test]
+fn mysql_pretty_labels_ordinals() {
+    let out = QueryBuilder::<MySql>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .to_sql_pretty();
+    assert_eq!(
+        out,
+        "SELECT `id` FROM `users` WHERE `status` = ?\nbinds:\n  ?1 = Text(\"active\")"
+    );
 }

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -1,0 +1,54 @@
+//! 3.1.0: `to_sql_pretty` / `try_to_sql_pretty`.
+
+use chain_builder::{Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn pg_pretty_multi_bind() {
+    let out = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .where_gt("age", 21i64)
+        .to_sql_pretty();
+    assert_eq!(
+        out,
+        "SELECT \"id\" FROM \"users\" WHERE \"status\" = $1 AND \"age\" > $2\nbinds:\n  $1 = Text(\"active\")\n  $2 = I64(21)"
+    );
+}
+
+#[test]
+fn sqlite_pretty_labels_ordinals() {
+    let out = QueryBuilder::<Sqlite>::table("users")
+        .select(["id"])
+        .where_eq("status", "active")
+        .where_gt("age", 21i64)
+        .to_sql_pretty();
+    assert_eq!(
+        out,
+        "SELECT \"id\" FROM \"users\" WHERE \"status\" = ? AND \"age\" > ?\nbinds:\n  ?1 = Text(\"active\")\n  ?2 = I64(21)"
+    );
+}
+
+#[test]
+fn pretty_zero_binds_is_sql_only() {
+    let out = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .to_sql_pretty();
+    assert_eq!(out, "SELECT \"id\" FROM \"users\"");
+}
+
+#[test]
+fn try_pretty_surfaces_same_build_error() {
+    let qb = QueryBuilder::<Postgres>::table("t").update(std::iter::empty::<(&str, Value)>());
+    assert_eq!(
+        qb.try_to_sql_pretty().unwrap_err(),
+        qb.try_to_sql().unwrap_err()
+    );
+}
+
+#[test]
+#[should_panic(expected = "update() requires at least one column")]
+fn pretty_panic_twin_message_parity() {
+    let _ = QueryBuilder::<Postgres>::table("t")
+        .update(std::iter::empty::<(&str, Value)>())
+        .to_sql_pretty();
+}

--- a/tests/set_expr.rs
+++ b/tests/set_expr.rs
@@ -1,0 +1,106 @@
+//! 3.1.0: UPDATE expressions — `set_raw`, `increment`, `decrement`.
+
+use chain_builder::{Postgres, QueryBuilder, Sqlite, Value};
+
+#[test]
+fn pg_update_with_increment_and_raw() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .update([("name", "x")])
+        .increment("views", 1i64)
+        .set_raw("updated_at", "NOW()", vec![])
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "name" = $1, "views" = "views" + $2, "updated_at" = NOW() WHERE "id" = $3"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("x".into()), Value::I64(1), Value::I64(9)]
+    );
+}
+
+#[test]
+fn pg_increment_alone_is_a_valid_update() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .increment("views", 1i64)
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "views" = "views" + $1 WHERE "id" = $2"#
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(9)]);
+}
+
+#[test]
+fn pg_decrement_emits_minus() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .decrement("stock", 3i64)
+        .to_sql();
+    assert_eq!(sql, r#"UPDATE "t" SET "stock" = "stock" - $1"#);
+    assert_eq!(binds, vec![Value::I64(3)]);
+}
+
+#[test]
+fn pg_set_raw_own_binds_positions() {
+    // One structured SET bind ($1) precedes the raw expr, so its hand-written
+    // placeholder is $2; WHERE continues at $3.
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .update([("a", 1i64)])
+        .set_raw("total", "price * $2", vec![Value::I64(3)])
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "a" = $1, "total" = price * $2 WHERE "id" = $3"#
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(3), Value::I64(9)]);
+}
+
+#[test]
+fn sqlite_update_exprs_use_question_marks() {
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("t")
+        .update([("name", "x")])
+        .increment("views", 1i64)
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "name" = ?, "views" = "views" + ? WHERE "id" = ?"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Text("x".into()), Value::I64(1), Value::I64(9)]
+    );
+}
+
+#[test]
+fn exprs_only_update_does_not_err_empty() {
+    let res = QueryBuilder::<Postgres>::table("t")
+        .increment("v", 1i64)
+        .try_to_sql();
+    assert!(res.is_ok());
+}
+
+#[test]
+fn empty_update_still_errs() {
+    // Both `set` and `set_exprs` empty → EmptyUpdate, same Display text.
+    let err = QueryBuilder::<Postgres>::table("t")
+        .update(std::iter::empty::<(&str, Value)>())
+        .try_to_sql()
+        .unwrap_err();
+    assert_eq!(err.to_string(), "update() requires at least one column");
+}
+
+#[test]
+fn method_switch_away_from_update_ignores_exprs() {
+    // Last-call-wins: insert() after set_raw() — exprs are ignored, like
+    // leftover `set` state is today.
+    let (sql, binds) = QueryBuilder::<Sqlite>::table("t")
+        .set_raw("x", "1", vec![])
+        .insert([("a", 1i64)])
+        .to_sql();
+    assert_eq!(sql, r#"INSERT INTO "t" ("a") VALUES (?)"#);
+    assert_eq!(binds, vec![Value::I64(1)]);
+}

--- a/tests/set_expr.rs
+++ b/tests/set_expr.rs
@@ -1,6 +1,6 @@
 //! 3.1.0: UPDATE expressions — `set_raw`, `increment`, `decrement`.
 
-use chain_builder::{Postgres, QueryBuilder, Sqlite, Value};
+use chain_builder::{MySql, Postgres, QueryBuilder, Sqlite, Value};
 
 #[test]
 fn pg_update_with_increment_and_raw() {
@@ -103,4 +103,30 @@ fn method_switch_away_from_update_ignores_exprs() {
         .to_sql();
     assert_eq!(sql, r#"INSERT INTO "t" ("a") VALUES (?)"#);
     assert_eq!(binds, vec![Value::I64(1)]);
+}
+
+#[test]
+fn pg_step_bind_advances_counter_before_raw() {
+    // The increment's bind goes through the placeholder counter ($1), so a
+    // following set_raw with its own bind must hand-write $2; WHERE is $3.
+    let (sql, binds) = QueryBuilder::<Postgres>::table("t")
+        .increment("views", 1i64)
+        .set_raw("total", "price * $2", vec![Value::I64(4)])
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"UPDATE "t" SET "views" = "views" + $1, "total" = price * $2 WHERE "id" = $3"#
+    );
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(4), Value::I64(9)]);
+}
+
+#[test]
+fn mysql_increment_backtick_quotes_both_sides() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("t")
+        .increment("views", 1i64)
+        .where_eq("id", 9i64)
+        .to_sql();
+    assert_eq!(sql, "UPDATE `t` SET `views` = `views` + ? WHERE `id` = ?");
+    assert_eq!(binds, vec![Value::I64(1), Value::I64(9)]);
 }

--- a/tests/subquery.rs
+++ b/tests/subquery.rs
@@ -216,14 +216,40 @@ fn pg_group_in_subquery_and_not_exists() {
                     .select(["user_id"])
                     .where_eq("k", 7i64),
             )
-            .where_not_exists(QueryBuilder::<Postgres>::table("audit").select(["1"]))
+            .where_not_exists(
+                QueryBuilder::<Postgres>::table("audit")
+                    .select(["1"])
+                    .where_eq("level", 3i64),
+            )
+        })
+        .to_sql();
+    // The second sub-query inside the same group continues numbering at $2.
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE ("id" IN (SELECT "user_id" FROM "ban" WHERE "k" = $1) AND NOT EXISTS (SELECT "1" FROM "audit" WHERE "level" = $2))"#
+    );
+    assert_eq!(binds, vec![Value::I64(7), Value::I64(3)]);
+}
+
+#[test]
+fn pg_or_group_with_subquery_first_suppresses_leading_or() {
+    // A subquery predicate as the sole content of an or_where group that is
+    // itself the first WHERE clause: the leading ` OR ` must be suppressed.
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .or_where(|g| {
+            g.where_exists(
+                QueryBuilder::<Postgres>::table("orders")
+                    .select(["1"])
+                    .where_eq("paid", true),
+            )
         })
         .to_sql();
     assert_eq!(
         sql,
-        r#"SELECT "id" FROM "users" WHERE ("id" IN (SELECT "user_id" FROM "ban" WHERE "k" = $1) AND NOT EXISTS (SELECT "1" FROM "audit"))"#
+        r#"SELECT "id" FROM "users" WHERE (EXISTS (SELECT "1" FROM "orders" WHERE "paid" = $1))"#
     );
-    assert_eq!(binds, vec![Value::I64(7)]);
+    assert_eq!(binds, vec![Value::Bool(true)]);
 }
 
 #[test]

--- a/tests/subquery.rs
+++ b/tests/subquery.rs
@@ -177,3 +177,71 @@ fn regression_plain_builder_unchanged() {
         vec![Value::Bool(true), Value::I64(18), Value::I64(10)]
     );
 }
+
+// --- 3.1.0: subquery predicates inside and_where / or_where groups ---
+
+#[test]
+fn pg_group_where_exists_continuity() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .where_eq("active", true)
+        .and_where(|g| {
+            g.where_exists(
+                QueryBuilder::<Postgres>::table("orders")
+                    .select(["1"])
+                    .where_column("orders.user_id", "=", "users.id")
+                    .where_gt("total", 100i64),
+            )
+            .or_where(|h| h.where_eq("vip", true))
+        })
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE "active" = $1 AND (EXISTS (SELECT "1" FROM "orders" WHERE "orders"."user_id" = "users"."id" AND "total" > $2) OR ("vip" = $3))"#
+    );
+    assert_eq!(
+        binds,
+        vec![Value::Bool(true), Value::I64(100), Value::Bool(true)]
+    );
+}
+
+#[test]
+fn pg_group_in_subquery_and_not_exists() {
+    let (sql, binds) = QueryBuilder::<Postgres>::table("users")
+        .select(["id"])
+        .and_where(|g| {
+            g.where_in_subquery(
+                "id",
+                QueryBuilder::<Postgres>::table("ban")
+                    .select(["user_id"])
+                    .where_eq("k", 7i64),
+            )
+            .where_not_exists(QueryBuilder::<Postgres>::table("audit").select(["1"]))
+        })
+        .to_sql();
+    assert_eq!(
+        sql,
+        r#"SELECT "id" FROM "users" WHERE ("id" IN (SELECT "user_id" FROM "ban" WHERE "k" = $1) AND NOT EXISTS (SELECT "1" FROM "audit"))"#
+    );
+    assert_eq!(binds, vec![Value::I64(7)]);
+}
+
+#[test]
+fn mysql_group_not_in_subquery() {
+    let (sql, binds) = QueryBuilder::<MySql>::table("users")
+        .select(["id"])
+        .and_where(|g| {
+            g.where_not_in_subquery(
+                "id",
+                QueryBuilder::<MySql>::table("ban")
+                    .select(["user_id"])
+                    .where_eq("k", 7i64),
+            )
+        })
+        .to_sql();
+    assert_eq!(
+        sql,
+        "SELECT `id` FROM `users` WHERE (`id` NOT IN (SELECT `user_id` FROM `ban` WHERE `k` = ?))"
+    );
+    assert_eq!(binds, vec![Value::I64(7)]);
+}


### PR DESCRIPTION
Four additive features for 3.1.0 (no breaking changes, no MSRV change, no new deps). Spec: `docs/superpowers/specs/2026-06-10-v3.1-tier1-design.md`; plan: `docs/superpowers/plans/2026-06-10-v3.1-tier1.md`.

## Features

- **Subquery predicates inside `and_where`/`or_where` groups** — `WhereBuilder` gains `where_exists` / `where_not_exists` / `where_in_subquery` / `where_not_in_subquery`, mirroring the `QueryBuilder` methods (placeholder continuity included). Zero compiler changes — the predicate variants already rendered inside groups; tests prove it.
- **UPDATE expressions** — `set_raw(col, expr, binds)` (verbatim escape hatch, `where_raw` contract) + structured `increment(col, by)` / `decrement(col, by)`. New `set_exprs` field; the INSERT-shared `set` field is untouched. `EmptyUpdate` now fires only when both lists are empty (Display text unchanged).
- **`escape_like()`** at the crate root — promoted from the cookbook recipe, byte-identical behavior.
- **`to_sql_pretty()` / `try_to_sql_pretty()`** — human-readable `(sql, binds)` for logs; twin-API policy; output not a stability contract; sensitive-data warning in rustdoc.

## Docs

- Book: UPDATE-expressions section, subquery-in-groups, cookbook search page now uses the crate `escape_like` (+ pre-existing fence bug fixed), `to_sql_pretty` in binds page, `set_raw` added to the security escape-hatch inventory (six → seven).
- CHANGELOG `[Unreleased]` — rename to `[3.1.0]` at release per the usual flow.

## Verification (run locally, full matrix)

- `cargo fmt --check` + `cargo clippy --all-features --all-targets -- -D warnings` clean
- `cargo test --all-features`: **256 passed, 0 failed** (baseline 227 + 25 new integration tests + 4 new doctests)
- `cargo test --features sqlx_postgres,sqlx_sqlite` (publish combo): **243 passed, 0 failed** (baseline 214)
- `mdbook build docs/book` exit 0; the 3 rustdoc warnings are pre-existing
- Manual smoke: all four features combined in one UPDATE query — placeholder continuity `$1`–`$5` across SET → WHERE → subquery → group verified by eye

Every feature commit was followed by a spec-compliance review and a code-quality review; review fixes are the `review:` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)