### PR TITLE
docs(site): brand 'Chain builder' + wider search box

### DIFF
--- a/docs/site/.vitepress/config.mts
+++ b/docs/site/.vitepress/config.mts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress'
 const repo = 'https://github.com/AssetsArt/chain-builder'
 
 export default defineConfig({
-  title: 'chain-builder',
+  title: 'Chain builder',
   description:
     'A typed, dialect-aware SQL query builder for Rust (PostgreSQL/MySQL/SQLite)',
   base: '/chain-builder/',

--- a/docs/site/.vitepress/theme/custom.css
+++ b/docs/site/.vitepress/theme/custom.css
@@ -16,3 +16,10 @@
   --vp-c-brand-3: #139069; /* solid button bg on dark (700) */
   --vp-c-brand-soft: rgba(27, 207, 150, 0.16);
 }
+
+/* Widen the nav search box — the default button reads too short. */
+@media (min-width: 768px) {
+  .DocSearch-Button {
+    min-width: 280px;
+  }
+}

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,7 +1,7 @@
 ---
 layout: home
 hero:
-  name: chain-builder
+  name: Chain builder
   text: Typed SQL query builder for Rust
   tagline: One dialect-aware builder for PostgreSQL, MySQL, and SQLite — values always bound, identifiers always escaped.
   actions:


### PR DESCRIPTION
Two small post-launch tweaks to the VitePress site, verified in a local preview screenshot:

- **Brand reads "Chain builder"** — hero name and nav site title (the crate/install name and `description` stay `chain-builder`).
- **Wider nav search box** — `.DocSearch-Button` gets `min-width: 280px` on desktop (≥768px); the default rendered too short.

Build green; rendered HTML confirms both. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)